### PR TITLE
Fix mixed usage of get_dataframe() and iterator in python udfs

### DIFF
--- a/flavors/docs/py_dataframe.md
+++ b/flavors/docs/py_dataframe.md
@@ -39,11 +39,11 @@ Output:
 | 2 | b | FALSE |
 
 
-### Mixed usage of get_dataframes and iterator
+## Mixed usage of get_dataframe() and iterator
 
-Some special attention needs the case were you mix the usage of get_dataframes and the iterator functions. The defined behavior is as following:
+Some special attention needs to be paid to the case where you mix the usage of `get_dataframe` and the iterator functions. The defined behavior is the following: A `get_dataframe` call consumes as many rows as specified in `num_rows`, and after this the iterator points to next row after the consumed ones.
 
-A get_dataframes call consumes as many rows as specified in num_rows and the after this the iterator points to next row after the consumed ones. The following example iterates over a Table with number from 0 to 9. In each iteration the get_dataframes call consumes exactly one row. It than emits this row and additionally emits the row at which the iterator points at after the call of get_dataframes. 
+The following example iterates over a table with numbers from 0 to 9. In each iteration the `get_dataframe` call consumes exactly one row. It then emits this row and additionally the row to which the iterator points after calling `get_dataframe`.
 
 ```python
 import pyexasol

--- a/flavors/docs/py_dataframe.md
+++ b/flavors/docs/py_dataframe.md
@@ -37,3 +37,47 @@ Output:
 | --- | --- | --- |
 | 1 | a | TRUE |
 | 2 | b | FALSE |
+
+
+### Mixed usage of get_dataframes and iterator
+
+Some special attention needs the case were you mix the usage of get_dataframes and the iterator functions. The defined behavior is as following:
+
+A get_dataframes call consumes as many rows as specified in num_rows and the after this the iterator points to next row after the consumed ones. The following example iterates over a Table with number from 0 to 9. In each iteration the get_dataframes call consumes exactly one row. It than emits this row and additionally emits the row at which the iterator points at after the call of get_dataframes. 
+
+```python
+import pyexasol
+import textwrap
+
+conn = pyexasol.connect(dsn=EXASOL_HOST, user=EXASOL_USER, password=EXASOL_PASSWORD, compression=True)
+conn.execute(f"ALTER SESSION SET SCRIPT_LANGUAGES='{EXASOL_SCRIPT_LANGUAGES}'")
+
+conn.execute('CREATE OR REPLACE TABLE TEST3(C0 INT IDENTITY, C1 INTEGER)')
+for i in range(10):
+    conn.execute('INSERT INTO TEST3 (C1) VALUES (%s)' % i)
+
+conn.execute(textwrap.dedent('''
+    CREATE OR REPLACE PYTHON3 SET SCRIPT foo(C1 INTEGER) EMITS(R VARCHAR(1000)) AS
+    def run(ctx):
+        BATCH_ROWS = 1
+        while True:
+            df = ctx.get_dataframe(num_rows=BATCH_ROWS)
+            if df is None:
+                break
+            ctx.emit(df.applymap(lambda x: "df_"+str(x)))
+            try:
+                ctx.emit("getattr_"+str(ctx.C1))
+                ctx.emit("eob") # end of batch
+            except:
+                ctx.emit("eoi") # end of iteration
+    /
+    '''))
+rows = conn.execute('SELECT foo(C1) FROM TEST3').fetchall()
+print(rows)
+conn.close()
+
+# Expected Output
+# [('df_0',), ('getattr_1',), ('eob',), ('df_1',), ('getattr_2',), ('eob',), ('df_2',), ('getattr_3',), ('eob',), ('df_3',), ('getattr_4',), ('eob',), ('df_4',), ('getattr_5',), ('eob',), ('df_5',), ('getattr_6',), ('eob',), ('df_6',), ('getattr_7',), ('eob',), ('df_7',), ('getattr_8',), ('eob',), ('df_8',), ('getattr_9',), ('eob',), ('df_9',), ('eoi',)]
+```
+
+

--- a/src/exascript_python_wrap.py
+++ b/src/exascript_python_wrap.py
@@ -216,7 +216,6 @@ class exaiter(object):
             return None
         self.__cache = [None] * len(self.__cache)
         df = pyextdataframe.get_dataframe(self, num_rows, start_col)
-
         return df 
     def reset(self):
         return self.next(reset = True)

--- a/src/exascript_python_wrap.py
+++ b/src/exascript_python_wrap.py
@@ -214,7 +214,10 @@ class exaiter(object):
             # Return None the first time there is no data
             self.__dataframe_finished = True
             return None
-        return pyextdataframe.get_dataframe(self, num_rows, start_col)
+        self.__cache = [None] * len(self.__cache)
+        df = pyextdataframe.get_dataframe(self, num_rows, start_col)
+
+        return df 
     def reset(self):
         return self.next(reset = True)
     def size(self):

--- a/tests/test/python3/dataframe.py
+++ b/tests/test/python3/dataframe.py
@@ -241,7 +241,7 @@ class PandasDataFrame(udf.TestCase):
 
     def test_dataframe_set_emits_iter_getattr(self):
         self.query(udf.fixindent('''
-            CREATE OR REPLACE PYTHON3_60 SET SCRIPT
+            CREATE OR REPLACE PYTHON SET SCRIPT
             foo(%s)
             EMITS(R VARCHAR(1000)) AS
             def run(ctx):

--- a/tests/test/python3/dataframe.py
+++ b/tests/test/python3/dataframe.py
@@ -52,8 +52,8 @@ class PandasDataFrame(udf.TestCase):
         self.test3_col_tuple = []
         self.test3_num_rows = 10
         for i in range(self.test3_num_rows):
-            col_vals = (str(i),)
-            self.test3_col_tuple.append(col_vals)
+            col_vals = str(i)
+            self.test3_col_tuple.append((col_vals,))
             self.query('INSERT INTO TEST3 (%s) VALUES (%s)' % (self.test3_col_names, col_vals))
 
     def test_dataframe_scalar_emits(self):

--- a/tests/test/python3/dataframe.py
+++ b/tests/test/python3/dataframe.py
@@ -46,6 +46,15 @@ class PandasDataFrame(udf.TestCase):
         self.col_tuple_null = (None, None, None, None, None, None, None, None, None, None, None)
 
 
+        self.test3_col_names = 'C1'
+        self.test3_col_defs = 'C1 INTEGER'
+        self.query('CREATE TABLE TEST3(C0 INT IDENTITY, %s)' % (self.test3_col_defs))
+        self.test3_col_tuple = []
+        self.test3_num_rows = 10
+        for i in range(self.test3_num_rows):
+            col_vals = (str(i),)
+            self.test3_col_tuple.append(col_vals)
+            self.query('INSERT INTO TEST3 (%s) VALUES (%s)' % (self.test3_col_names, col_vals))
 
     def test_dataframe_scalar_emits(self):
         self.query(udf.fixindent('''
@@ -229,6 +238,34 @@ class PandasDataFrame(udf.TestCase):
             ''' % (self.col_defs, self.col_defs)))
         rows = self.query('SELECT foo(%s) FROM FN2.TEST1' % (self.col_names))
         self.assertRowsEqual([self.col_tuple]*self.num_rows, rows)
+
+    def test_dataframe_set_emits_iter_getattr(self):
+        self.query(udf.fixindent('''
+            CREATE OR REPLACE PYTHON3_60 SET SCRIPT
+            foo(%s)
+            EMITS(R VARCHAR(1000)) AS
+            def run(ctx):
+                BATCH_ROWS = 1
+                while True:
+                    df = ctx.get_dataframe(num_rows=BATCH_ROWS)
+                    if df is None:
+                        break
+                    ctx.emit(df.applymap(lambda x: "df_"+str(x)))
+                    try:
+                        ctx.emit("getattr_"+str(ctx.C1))
+                        ctx.emit("eob") # end of batch
+                    except:
+                        ctx.emit("eoi") # end of iteration
+            /
+            ''' % (self.test3_col_defs)))
+        rows = self.query('SELECT foo(%s) FROM FN2.TEST3' % (self.test3_col_names))
+        expected_result = [("df_"+str(self.test3_col_tuple[0][0]),)]
+        for i in range(1,self.test3_num_rows):
+            expected_result.append(("getattr_"+str(self.test3_col_tuple[i][0]),))
+            expected_result.append(("eob",))
+            expected_result.append(("df_"+str(self.test3_col_tuple[i][0]),))
+        expected_result.append(("eoi",))
+        self.assertRowsEqual(expected_result, rows)
 
     def test_dataframe_set_emits_iter_exception(self):
         self.query(udf.fixindent('''


### PR DESCRIPTION
If the user used get_dataframe() in a python udf the cache for the iterator was not emptied which lead to wrong behavior of the iterator. After using get_dataframe() without an call to next() the __getitem__ or __getattr__ method returned the first cached value. The following example shows alternately a dataframe with one row returned by get_dataframe() and a call to ctx.ID without any call to next. 

[('   ID 0   1',), ('2',), ('   ID 0   2',), ('2',), ('   ID 0   3',), ('2',), ('   ID 0   4',), ('2',), ('   ID 0   5',), ('2',), ('   ID 0   6',)]

The call ctx.ID returns everytime to '2' which is not correct. The expected ouptut would be:

[('   ID 0   1',), ('2',), ('   ID 0   2',), ('3',), ('   ID 0   3',), ('4',), ('   ID 0   4',), ('5',), ('   ID 0   5',), ('6',), ('   ID 0   6',)]

This pull request fixes this issue, adds a test case for it and adds an example to the documentation of the dataframe support for python which describes the expected behavior.