### PR TITLE
Bugfixes for exaslct starter script and fixing tensorflow version to 1.13.1

### DIFF
--- a/exaslct
+++ b/exaslct
@@ -10,6 +10,7 @@ SCRIPT_DIR="$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")"
 
 run () {
     PIPENV_BIN="$1"
+    cd "$SCRIPT_DIR"
     echo "Using following pipenv executable: $PIPENV_BIN"
     if $PIPENV_BIN --venv &> /dev/null;
     then
@@ -23,7 +24,6 @@ run () {
         echo "Installing dependencies"
         $PIPENV_BIN install
     fi
-    cd "$SCRIPT_DIR"
     export PYTHONPATH="."
     $PIPENV_BIN run python3 exaslct_src/exaslct.py $COMMAND_LINE_ARGS
 }

--- a/flavors/python3-ds-EXASOL-6.0.0/flavor_base/flavor_base_deps/packages/pip3_packages
+++ b/flavors/python3-ds-EXASOL-6.0.0/flavor_base/flavor_base_deps/packages/pip3_packages
@@ -1,6 +1,6 @@
 pyexasol
 keras
-tensorflow
+tensorflow==1.13.1
 tensorflow-hub
 kmodes
 seaborn

--- a/flavors/python3-ds-EXASOL-6.1.0/flavor_base/flavor_base_deps/packages/pip3_packages
+++ b/flavors/python3-ds-EXASOL-6.1.0/flavor_base/flavor_base_deps/packages/pip3_packages
@@ -1,6 +1,6 @@
 pyexasol
 keras
-tensorflow
+tensorflow==1.13.1
 tensorflow-hub
 kmodes
 seaborn


### PR DESCRIPTION
This pull request fixes bugs in the exaslct starter script for the case that exaslct doesn't get called from the repository root. Further, this pull requests fixes the tensorflow version to 1.13.1, because tensorflow 1.14.0 and probably tensorflow 2.0 raise error during import in the UDF. See, more details [here](https://github.com/exasol/script-languages/issues/43).