### PR TITLE
Fix missing cleanup call after exception in run

### DIFF
--- a/exaudfclient/base/BUILD
+++ b/exaudfclient/base/BUILD
@@ -52,6 +52,13 @@ config_setting(
         },
 )
 
+config_setting(
+    name = "stdout_to_bucketfs",
+    define_values = {
+        "wrapper_type": "stdout_to_bucketfs",
+        },
+)
+
 cc_library(
     name = "debug_message_h",
     hdrs = [
@@ -131,6 +138,7 @@ sh_library(
     srcs=select({
         "//:valgrind_wrapper": ["//:create_binary_wrapper_valgrind.sh"],
         "//:valgrind_massif_wrapper": ["//:create_binary_wrapper_valgrind_massif.sh"],
+        "//:stdout_to_bucketfs": ["//:create_binary_wrapper_stdout_to_bucketfs.sh"],
         "//conditions:default": ["//:create_binary_wrapper.sh"]
     })
 ) 

--- a/exaudfclient/base/create_binary_wrapper_stdout_to_bucketfs.sh
+++ b/exaudfclient/base/create_binary_wrapper_stdout_to_bucketfs.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+set -o errexit
+set -o pipefail
+CLIENT_BINARY=$1
+CLIENT_WRAPPER=$2
+WRAPPER_TEMPLATE=$3
+touch "$CLIENT_WRAPPER"
+cat "$WRAPPER_TEMPLATE" >> "$CLIENT_WRAPPER"
+echo >> "$CLIENT_WRAPPER"
+echo 'NAME="$1"' >> "$CLIENT_WRAPPER"
+echo 'OUTPUT_FILE="/tmp/$(echo $NAME | sed s#[/:]##g)"' >> "$CLIENT_WRAPPER"
+echo ./$(basename "$CLIENT_BINARY") '$*' '&> "$OUTPUT_FILE"' >>  "$CLIENT_WRAPPER"
+echo 'UPLOAD="curl --fail -X PUT -T $OUTPUT_FILE http://w:write@localhost:6583/default$OUTPUT_FILE"' >>  "$CLIENT_WRAPPER"
+echo 'echo $UPLOAD' >>  "$CLIENT_WRAPPER"
+echo '$UPLOAD' >>  "$CLIENT_WRAPPER"
+

--- a/exaudfclient/base/exaudflib/exaudflib.cc
+++ b/exaudfclient/base/exaudflib/exaudflib.cc
@@ -1495,7 +1495,46 @@ public:
     }
 };
 
+unsigned int handle_error(zmq::socket_t& socket, std::string socket_name, SWIGVM* vm, std::string msg, bool shutdown_vm=false){
+    DBG_STREAM_MSG(cerr,"### handle error in '" << socket_name << " (" << ::getppid() << ',' << ::getpid() << "): " << msg);
+    try{
+        if(vm!=nullptr && shutdown_vm){
+            vm->shutdown();
+            if (vm->exception_msg.size()>0) {
+                msg ="Caught exception\n\n"+msg+"\n\n and caught another exception during cleanup\n\n"+vm->exception_msg;
+                msg=vm->exception_msg;
+            }
+        } 
+        delete_vm(vm);
+    }  catch (SWIGVM::exception &err) {
+        DBG_STREAM_MSG(cerr,"### SWIGVM crashing with name '" << socket_name << " (" << ::getppid() << ',' << ::getpid() << "): " << err.what());
+    }catch(std::exception& err){
+        DBG_STREAM_MSG(cerr,"### SWIGVM crashing with name '" << socket_name << " (" << ::getppid() << ',' << ::getpid() << "): " << err.what());
+    }catch(...){
+        DBG_STREAM_MSG(cerr,"### SWIGVM crashing with name '" << socket_name << " (" << ::getppid() << ',' << ::getpid() << "): ");
+    }
+    try{
+        send_close(socket, msg);
+        ::sleep(1); // give me a chance to die with my parent process
+    }  catch (SWIGVM::exception &err) {
+        DBG_STREAM_MSG(cerr,"### SWIGVM crashing with name '" << socket_name << " (" << ::getppid() << ',' << ::getpid() << "): " << err.what());
+    }catch(std::exception& err){
+        DBG_STREAM_MSG(cerr,"### SWIGVM crashing with name '" << socket_name << " (" << ::getppid() << ',' << ::getpid() << "): " << err.what());
+    }catch(...){
+        DBG_STREAM_MSG(cerr,"### SWIGVM crashing with name '" << socket_name << " (" << ::getppid() << ',' << ::getpid() << "): ");
+    }
 
+    try{
+        stop_all(socket);
+    }  catch (SWIGVM::exception &err) {
+        DBG_STREAM_MSG(cerr,"### SWIGVM crashing with name '" << socket_name << " (" << ::getppid() << ',' << ::getpid() << "): " << err.what());
+    }catch(std::exception& err){
+        DBG_STREAM_MSG(cerr,"### SWIGVM crashing with name '" << socket_name << " (" << ::getppid() << ',' << ::getpid() << "): " << err.what());
+    }catch(...){
+        DBG_STREAM_MSG(cerr,"### SWIGVM crashing with name '" << socket_name << " (" << ::getppid() << ',' << ::getpid() << "): ");
+    }
+    return 1;
+}
 
 
 } // namespace SWIGVMContainers
@@ -1603,12 +1642,11 @@ reinit:
     SWIGVM_params_ref->sock = &socket;
     SWIGVM_params_ref->exch = &exchandler;
 
-    SWIGVM*vm=nullptr;
+    SWIGVM* vm=nullptr;
 
     if (!send_init(socket, socket_name)) {
         if (!get_remote_client() && exchandler.exthrowed) {
-            send_close(socket, exchandler.exmsg);
-            goto error;
+            return handle_error(socket, socket_name, vm, exchandler.exmsg, false);
         }else{
             goto reinit;
         }
@@ -1628,19 +1666,17 @@ reinit:
     SWIGVM_params_ref->node_id = g_node_id;
     SWIGVM_params_ref->vm_id = g_vm_id;
     SWIGVM_params_ref->singleCallMode = g_singleCallMode;
-
+    bool shutdown_vm_in_case_of_error = false;
     try {
         vm = vmMaker();
         if (vm == nullptr) {
-            send_close(socket, "Unknown or unsupported VM type");
-            goto error;
+            return handle_error(socket, socket_name, vm, "Unknown or unsupported VM type", false);
         }
         if (vm->exception_msg.size()>0) {
-            throw SWIGVM::exception(vm->exception_msg.c_str());
+            return handle_error(socket, socket_name, vm, vm->exception_msg.c_str(), false);
         }
-
+        shutdown_vm_in_case_of_error = true;
         use_zmq_socket_locks = vm->useZmqSocketLocks();
-
         if (g_singleCallMode) {
             ExecutionGraph::EmptyDTO noArg; // used as dummy arg
             for (;;) {
@@ -1677,8 +1713,7 @@ reinit:
                             break;
                     }
                     if (vm->exception_msg.size()>0) {
-                        send_close(socket, vm->exception_msg);
-                        goto error;
+                        return handle_error(socket, socket_name, vm, vm->exception_msg,true);
                     }
 
                     if (vm->calledUndefinedSingleCall.size()>0) {
@@ -1700,8 +1735,7 @@ reinit:
                 while(!vm->run_())
                 {
                     if (vm->exception_msg.size()>0) {
-                        send_close(socket, vm->exception_msg);
-                        goto error;
+                        return handle_error(socket, socket_name, vm, vm->exception_msg,true);
                     }
                 }
                 if (!send_done(socket))
@@ -1713,36 +1747,26 @@ reinit:
         {
             vm->shutdown();
             if (vm->exception_msg.size()>0) {
-                send_close(socket, vm->exception_msg);
-                goto error;
+                return handle_error(socket, socket_name, vm, vm->exception_msg,false);
             }
         }
         send_finished(socket);
     }  catch (SWIGVM::exception &err) {
         DBG_STREAM_MSG(cerr,"### SWIGVM crashing with name '" << socket_name << " (" << ::getppid() << ',' << ::getpid() << "): " << err.what());
-        send_close(socket, err.what());
-        goto error;
+        return handle_error(socket, socket_name, vm, err.what(),shutdown_vm_in_case_of_error);
     } catch (std::exception &err) {
         DBG_STREAM_MSG(cerr,"### SWIGVM crashing with name '" << socket_name << " (" << ::getppid() << ',' << ::getpid() << "): " << err.what());
-        send_close(socket, err.what());
-        goto error;
+        return handle_error(socket, socket_name, vm, err.what(),shutdown_vm_in_case_of_error);
     } catch (...) {
         DBG_STREAM_MSG(cerr,"### SWIGVM crashing with name '" << socket_name << " (" << ::getppid() << ',' << ::getpid() << ')');
-        send_close(socket, "Internal/Unknown error");
-        goto error;
+        return handle_error(socket, socket_name, vm, "Internal/Unknown error",shutdown_vm_in_case_of_error);
     }
-
 
     DBG_STREAM_MSG(cerr,"### SWIGVM finishing with name '" << socket_name << " (" << ::getppid() << ',' << ::getpid() << ')');
 
     delete_vm(vm);
     stop_all(socket);
     return 0;
-
-error:
-    delete_vm(vm);
-    stop_all(socket);
-    return 1;
 }
 
 

--- a/exaudfclient/base/exaudflib/exaudflib.cc
+++ b/exaudfclient/base/exaudflib/exaudflib.cc
@@ -1501,8 +1501,8 @@ unsigned int handle_error(zmq::socket_t& socket, std::string socket_name, SWIGVM
         if(vm!=nullptr && shutdown_vm){
             vm->shutdown();
             if (vm->exception_msg.size()>0) {
+                DBG_STREAM_MSG(cerr,"### Caught error in vm->shutdown '" << socket_name << " (" << ::getppid() << ',' << ::getpid() << "): " << vm->exception_msg);
                 msg ="Caught exception\n\n"+msg+"\n\n and caught another exception during cleanup\n\n"+vm->exception_msg;
-                msg=vm->exception_msg;
             }
         } 
         delete_vm(vm);

--- a/tests/test/python/general.py
+++ b/tests/test/python/general.py
@@ -72,6 +72,21 @@ class PythonInterpreter(udf.TestCase):
         with self.assertRaisesRegexp(Exception, '4711'):
             self.query('SELECT foo() FROM dual')
 
+    def test_exception_in_run_and_cleanup_is_propagated(self):
+        self.query(udf.fixindent('''
+            CREATE OR REPLACE python SCALAR SCRIPT
+            foo()
+            RETURNS INT AS
+
+            def run(ctx):
+                raise ValueError('42')
+
+            def cleanup():
+                raise ValueError('4711')
+            '''))
+        with self.assertRaisesRegexp(Exception, '42.*4711'):
+            self.query('SELECT foo() FROM dual')
+
     def test_cleanup_has_global_context(self):
         self.query(udf.fixindent('''
             CREATE OR REPLACE python SCALAR SCRIPT

--- a/tests/test/python/network.py
+++ b/tests/test/python/network.py
@@ -154,7 +154,6 @@ class CleanupTest(udf.TestCase):
         self.query('DROP SCHEMA t1 CASCADE', ignore_errors=True)
         self.query('CREATE SCHEMA t1')
 
-    @skipIf(running_in_travis, reason="This test is not supported when running in travis")    
     def test_cleanup_is_called_at_least_once(self):
         with MessageBox() as mb:
             host, port = mb.address
@@ -188,7 +187,6 @@ class CleanupTest(udf.TestCase):
 
         self.assertIn('foobar', mb.data)
 
-    @skipIf(running_in_travis, reason="This test is not supported when running in travis")
     def test_cleanup_is_called_exactly_once_for_each_vm(self):
         with MessageBox() as mb:
             host, port = mb.address
@@ -232,7 +230,6 @@ class CleanupTest(udf.TestCase):
         self.assertEquals(init, cleanup)
         self.assertEquals(sorted(set(init)), init)
 
-    @skipIf(running_in_travis, reason="This test is not supported when running in travis")
     def test_cleanup_is_called_exactly_once_for_each_vm_with_crash_in_run(self):
         with MessageBox() as mb:
             host, port = mb.address


### PR DESCRIPTION
- move error handling code to function in exaudflib
- reactivate network.py tests to detect this bug
- return combined exception if run and cleanup throw exceptions
- add create_binary_wrapper_stdout_to_bucketfs for debugging
