### PR TITLE
Fixes and improvements on Google Cloud Build CI Setup

### DIFF
--- a/exaslct_src/cli/commands/__init__.py
+++ b/exaslct_src/cli/commands/__init__.py
@@ -7,3 +7,5 @@ from .export import export
 from .save import save
 from .spawn_test_environment import spawn_test_environment
 from .generate_language_activation import generate_language_activation
+from .build_test_container import build_test_container
+from .push_test_container import push_test_container

--- a/exaslct_src/cli/commands/build_test_container.py
+++ b/exaslct_src/cli/commands/build_test_container.py
@@ -1,0 +1,59 @@
+from typing import Tuple
+
+from exaslct_src.cli.cli import cli
+from exaslct_src.cli.common import set_build_config, set_docker_repository_config, run_task, add_options, \
+    set_job_id
+from exaslct_src.cli.options \
+    import build_options, system_options, docker_repository_options
+from exaslct_src.lib.analyze_test_container import DockerTestContainerBuild, AnalyzeTestContainer
+from exaslct_src.lib.docker_build import DockerBuild
+
+
+@cli.command()
+@add_options(build_options)
+@add_options(docker_repository_options)
+@add_options(system_options)
+def build_test_container(
+        force_rebuild: bool,
+        force_rebuild_from: Tuple[str, ...],
+        force_pull: bool,
+        output_directory: str,
+        temporary_base_directory: str,
+        log_build_context_content: bool,
+        cache_directory: str,
+        build_name: str,
+        source_docker_repository_name: str,
+        source_docker_tag_prefix: str,
+        source_docker_username: str,
+        source_docker_password: str,
+        target_docker_repository_name: str,
+        target_docker_tag_prefix: str,
+        target_docker_username: str,
+        target_docker_password: str,
+        workers: int,
+        task_dependencies_dot_file: str):
+    """
+    This command builds all stages of the test container for the test environment.
+    If stages are cached in a docker registry, they command is going to pull them,
+    instead of building them.
+    """
+    set_build_config(force_rebuild,
+                     force_rebuild_from,
+                     force_pull,
+                     log_build_context_content,
+                     output_directory,
+                     temporary_base_directory,
+                     cache_directory,
+                     build_name)
+    # Use AnalyzeTestContainer to ensure that all luigi processes got it loaded
+    analyze_task = AnalyzeTestContainer.__class__.__name__
+
+    set_docker_repository_config(source_docker_password, source_docker_repository_name, source_docker_username,
+                                 source_docker_tag_prefix, "source")
+    set_docker_repository_config(target_docker_password, target_docker_repository_name, target_docker_username,
+                                 target_docker_tag_prefix, "target")
+    set_job_id(DockerTestContainerBuild.__name__)
+    task_creator = lambda: DockerTestContainerBuild()
+    success, task = run_task(task_creator, workers, task_dependencies_dot_file)
+    if not success:
+        exit(1)

--- a/exaslct_src/cli/commands/push.py
+++ b/exaslct_src/cli/commands/push.py
@@ -2,21 +2,18 @@ from typing import Tuple
 
 from click._unicodefun import click
 
-from exaslct_src.lib.docker_push import DockerPush
+from exaslct_src.lib.docker_push import DockerFlavorsPush
 from exaslct_src.cli.cli import cli
 from exaslct_src.cli.common import set_build_config, set_docker_repository_config, run_task, add_options, \
     import_build_steps, set_job_id
 from exaslct_src.cli.options \
-    import build_options, flavor_options, system_options, docker_repository_options, goal_options
+    import build_options, flavor_options, system_options, docker_repository_options, goal_options, push_options
 
 
 @cli.command()
 @add_options(flavor_options)
 @add_options(goal_options)
-@click.option('--force-push/--no-force-push', default=False,
-              help="Forces the system to overwrite existing images in registry for build steps that run")
-@click.option('--push-all/--no-push-all', default=False,
-              help="Forces the system to push all images of build-steps that are specified by the goals")
+@add_options(push_options)
 @add_options(build_options)
 @add_options(docker_repository_options)
 @add_options(system_options)
@@ -59,11 +56,11 @@ def push(flavor_path: Tuple[str, ...],
                                  source_docker_tag_prefix, "source")
     set_docker_repository_config(target_docker_password, target_docker_repository_name, target_docker_username,
                                  target_docker_tag_prefix, "target")
-    set_job_id(DockerPush.__name__)
-    task_creator = lambda: DockerPush(force_push=force_push,
-                                push_all=push_all,
-                                goals=list(goal),
-                                flavor_paths=list(flavor_path))
+    set_job_id(DockerFlavorsPush.__name__)
+    task_creator = lambda: DockerFlavorsPush(force_push=force_push,
+                                             push_all=push_all,
+                                             goals=list(goal),
+                                             flavor_paths=list(flavor_path))
     success, task = run_task(task_creator, workers, task_dependencies_dot_file)
     if not success:
         exit(1)

--- a/exaslct_src/cli/commands/push_test_container.py
+++ b/exaslct_src/cli/commands/push_test_container.py
@@ -1,0 +1,63 @@
+from typing import Tuple
+
+from exaslct_src.cli.cli import cli
+from exaslct_src.cli.common import set_build_config, set_docker_repository_config, run_task, add_options, \
+    set_job_id
+from exaslct_src.cli.options \
+    import build_options, system_options, docker_repository_options, push_options
+from exaslct_src.lib.analyze_test_container import DockerTestContainerBuild, AnalyzeTestContainer, \
+    DockerTestContainerPush
+from exaslct_src.lib.docker_build import DockerBuild
+
+
+@cli.command()
+@add_options(push_options)
+@add_options(build_options)
+@add_options(docker_repository_options)
+@add_options(system_options)
+def push_test_container(
+        force_push: bool,
+        push_all: bool,
+        force_rebuild: bool,
+        force_rebuild_from: Tuple[str, ...],
+        force_pull: bool,
+        output_directory: str,
+        temporary_base_directory: str,
+        log_build_context_content: bool,
+        cache_directory: str,
+        build_name: str,
+        source_docker_repository_name: str,
+        source_docker_tag_prefix: str,
+        source_docker_username: str,
+        source_docker_password: str,
+        target_docker_repository_name: str,
+        target_docker_tag_prefix: str,
+        target_docker_username: str,
+        target_docker_password: str,
+        workers: int,
+        task_dependencies_dot_file: str):
+    """
+    This command pushs all stages of the test container for the test environment.
+    If the stages do not exists locally, the system will build or pull them before the push.
+    """
+    set_build_config(force_rebuild,
+                     force_rebuild_from,
+                     force_pull,
+                     log_build_context_content,
+                     output_directory,
+                     temporary_base_directory,
+                     cache_directory,
+                     build_name)
+    # Use AnalyzeTestContainer to ensure that all luigi processes got it loaded
+    analyze_task = AnalyzeTestContainer.__class__.__name__
+
+    set_docker_repository_config(source_docker_password, source_docker_repository_name, source_docker_username,
+                                 source_docker_tag_prefix, "source")
+    set_docker_repository_config(target_docker_password, target_docker_repository_name, target_docker_username,
+                                 target_docker_tag_prefix, "target")
+    set_job_id(DockerTestContainerPush.__name__)
+    task_creator = lambda: DockerTestContainerPush(force_push=force_push,
+                                                   push_all=push_all)
+    success, task = run_task(task_creator, workers, task_dependencies_dot_file)
+    if not success:
+        exit(1)

--- a/exaslct_src/cli/options.py
+++ b/exaslct_src/cli/options.py
@@ -1,18 +1,19 @@
 from click._unicodefun import click
 
+
 def create_flavor_option(multiple):
-    help_message="Path to the directory with the flavor definition.\n" + \
-                 "The last segment of the path is used as the name of the flavor."
+    help_message = "Path to the directory with the flavor definition.\n" + \
+                   "The last segment of the path is used as the name of the flavor."
     if multiple:
-        help_addition = "The option can be repeated with different flavors.\n"+ \
+        help_addition = "The option can be repeated with different flavors.\n" + \
                         "The system will run the command for each flavor."
         help_message = help_message + "\n" + help_addition
 
     return click.option('--flavor-path',
-                         required=True,
-                         multiple=multiple,
-                         type=click.Path(exists=True, file_okay=False, dir_okay=True),
-                         help=help_message)
+                        required=True,
+                        multiple=multiple,
+                        type=click.Path(exists=True, file_okay=False, dir_okay=True),
+                        help=help_message)
 
 
 flavor_options = [create_flavor_option(multiple=True)]
@@ -158,6 +159,14 @@ build_options = [
                  help="Directory from where saved docker images can be loaded"),
     click.option('--build-name', default=None, type=str,
                  help="Name of the build. For example: Repository + CI Build Number"),
+]
+
+push_options = [
+    click.option('--force-push/--no-force-push', default=False,
+                 help="Forces the system to overwrite existing images in registry for build steps that run"),
+    click.option('--push-all/--no-push-all', default=False,
+                 help="Forces the system to push all images of build-steps that are specified by the goals")
+
 ]
 
 system_options = [

--- a/exaslct_src/lib/base/base_task.py
+++ b/exaslct_src/lib/base/base_task.py
@@ -127,34 +127,16 @@ class BaseTask(Task):
                 params_str[param_name] = params[param_name].serialize(param_value)
         return params_str
 
-    def _get_tmp_path_for_returns(self, name: str) -> Path:
-        return Path(self._get_tmp_path_for_task(), RETURN_TARGETS, name)
-
-    def _get_tmp_path_for_completion_target(self) -> Path:
-        return Path(self._get_tmp_path_for_task(), COMPLETION_TARGET)
-
-    def _get_tmp_path_for_run_dependencies(self) -> Path:
-        return Path(self._get_tmp_path_for_task(), RUN_DEPENDENCIES)
-
-    def _get_tmp_path_for_task(self) -> Path:
-        return Path(self._get_tmp_path_for_job(),
-                    self.task_id)
-
-    def _get_tmp_path_for_job(self) -> Path:
-        return Path(build_config().output_directory,
-                    job_config().job_id,
-                    "temp")
-
-    def _get_output_path_for_job(self) -> Path:
-        return Path(build_config().output_directory,
-                    job_config().job_id)
-
     def get_output_path(self) -> Path:
         path = Path(self._get_output_path_for_job(),
                     "outputs",
                     Path(*self._extend_output_path()))
         path.mkdir(parents=True, exist_ok=True)
         return path
+
+    def _get_output_path_for_job(self) -> Path:
+        return Path(build_config().output_directory,
+                    "jobs", job_config().job_id)
 
     def _extend_output_path(self):
         extension = self.extend_output_path()
@@ -165,6 +147,22 @@ class BaseTask(Task):
 
     def extend_output_path(self):
         return list(self.caller_output_path) + [self.task_id]
+    
+    def _get_tmp_path_for_job(self) -> Path:
+        return Path(self._get_output_path_for_job(), "temp")
+    
+    def _get_tmp_path_for_task(self) -> Path:
+        return Path(self._get_tmp_path_for_job(),
+                    self.task_id)
+
+    def _get_tmp_path_for_returns(self, name: str) -> Path:
+        return Path(self._get_tmp_path_for_task(), RETURN_TARGETS, name)
+
+    def _get_tmp_path_for_completion_target(self) -> Path:
+        return Path(self._get_tmp_path_for_task(), COMPLETION_TARGET)
+
+    def _get_tmp_path_for_run_dependencies(self) -> Path:
+        return Path(self._get_tmp_path_for_task(), RUN_DEPENDENCIES)
 
     def get_log_path(self) -> Path:
         path = Path(self.get_output_path(), "logs")

--- a/exaslct_src/lib/docker_push.py
+++ b/exaslct_src/lib/docker_push.py
@@ -2,16 +2,13 @@ from typing import Dict
 
 from exaslct_src.lib.docker_build import *
 from exaslct_src.lib.docker_flavor_build_base import DockerFlavorBuildBase
+from exaslct_src.lib.docker_push_parameter import DockerPushParameter
 from exaslct_src.lib.push_task_create_from_build_tasks import PushTaskCreatorFromBuildTasks
 
 
-class DockerPushParameter(Config):
+class DockerFlavorsPush(FlavorsBaseTask, DockerPushParameter):
     goals = luigi.ListParameter()
-    force_push = luigi.BoolParameter(False)
-    push_all = luigi.BoolParameter(False)
 
-
-class DockerPush(FlavorsBaseTask, DockerPushParameter):
     def register_required(self):
         tasks = self.create_tasks_for_flavors_with_common_params(
             DockerFlavorPush)  # type: Dict[str,DockerFlavorPush]
@@ -24,8 +21,6 @@ class DockerPush(FlavorsBaseTask, DockerPushParameter):
 
 class DockerFlavorPush(DockerFlavorBuildBase, DockerPushParameter):
     goals = luigi.ListParameter()
-    force_push = luigi.BoolParameter(False)
-    push_all = luigi.BoolParameter(False)
 
     def get_goals(self):
         return self.goals

--- a/exaslct_src/lib/docker_push_parameter.py
+++ b/exaslct_src/lib/docker_push_parameter.py
@@ -1,0 +1,7 @@
+import luigi
+from luigi import Config
+
+
+class DockerPushParameter(Config):
+    force_push = luigi.BoolParameter(False)
+    push_all = luigi.BoolParameter(False)

--- a/google-cloud-build/.env/env.template.yaml
+++ b/google-cloud-build/.env/env.template.yaml
@@ -7,5 +7,5 @@ config_bucket:
 key_ring_name: 
 key_name: 
 build_docker_repository:
-deploy_docker_repository:
+release_docker_repository:
 docker_user:

--- a/google-cloud-build/ci-scripts/build_branch.yaml
+++ b/google-cloud-build/ci-scripts/build_branch.yaml
@@ -44,7 +44,6 @@ steps:
   name: 'gcr.io/cloud-builders/gcloud'
   entrypoint: bash
   args: [
-          '-x',
           'google-cloud-build/ci-scripts/scripts/decrypt.sh',
           '${_DOCKER_PASSWORD}',
           'DOCKER_PASSWORD',

--- a/google-cloud-build/ci-scripts/build_branch.yaml
+++ b/google-cloud-build/ci-scripts/build_branch.yaml
@@ -1,14 +1,24 @@
 steps:
+- id: 'Decrypt Docker password'
+  name: 'gcr.io/cloud-builders/gcloud'
+  entrypoint: bash
+  args: [
+          'google-cloud-build/ci-scripts/scripts/decrypt.sh',
+          '${_DOCKER_PASSWORD}',
+          'DOCKER_PASSWORD',
+          '${_KEY_RING_NAME}',
+          '${_KEY_NAME}'
+          ]
 - id: 'Build build-container'
   name: 'gcr.io/cloud-builders/docker'
+  entrypoint: "bash"
   args: [
-          'build', 
-          '-t', 
-          'gcr.io/script-languages/build-container', 
-          'google-cloud-build/ci-scripts/scripts/'
+          'google-cloud-build/ci-scripts/scripts/build_or_pull_build_container.sh',
+          '${_BUILD_DOCKER_REPOSITORY}',
+          '${_DOCKER_USER}'
           ]
 - id: 'Build images'
-  name: 'gcr.io/script-languages/build-container'
+  name: 'exasol/script-languages:build-container'
   args: [
           'bash', 
           'google-cloud-build/ci-scripts/scripts/build.sh', 
@@ -25,7 +35,7 @@ steps:
           "$BUILD_ID"
           ]
 - id: 'Run tests'
-  name: 'gcr.io/script-languages/build-container'
+  name: 'exasol/script-languages:build-container'
   args: [
           'bash', 
           'google-cloud-build/ci-scripts/scripts/test.sh', 
@@ -40,18 +50,8 @@ steps:
           '${_FLAVOR}', 
           '$BUILD_ID'
           ]
-- id: 'Decrypt Docker password'
-  name: 'gcr.io/cloud-builders/gcloud'
-  entrypoint: bash
-  args: [
-          'google-cloud-build/ci-scripts/scripts/decrypt.sh',
-          '${_DOCKER_PASSWORD}',
-          'DOCKER_PASSWORD',
-          '${_KEY_RING_NAME}',
-          '${_KEY_NAME}'
-          ]
 - id: 'Push images to internal build cache with commit hash'
-  name: 'gcr.io/script-languages/build-container'
+  name: 'exasol/script-languages:build-container'
   args: [
           'bash',
           'google-cloud-build/ci-scripts/scripts/push.sh',
@@ -72,7 +72,7 @@ steps:
           '$BUILD_ID'
           ]
 - id: 'Push images to internal build cache without commit hash'
-  name: 'gcr.io/script-languages/build-container'
+  name: 'exasol/script-languages:build-container'
   args: [
           'bash',
           'google-cloud-build/ci-scripts/scripts/push.sh',

--- a/google-cloud-build/ci-scripts/build_branch.yaml
+++ b/google-cloud-build/ci-scripts/build_branch.yaml
@@ -51,19 +51,40 @@ steps:
           '${_KEY_RING_NAME}',
           '${_KEY_NAME}'
           ]
-- id: 'Push images to internal build cache'
+- id: 'Push images to internal build cache with commit hash'
   name: 'gcr.io/script-languages/build-container'
   args: [
           'bash',
           'google-cloud-build/ci-scripts/scripts/push.sh',
           '${_FLAVOR}',
-          '""',
+          '${_RELEASE_DOCKER_REPOSITORY}',
           '""',
           '${_BUILD_DOCKER_REPOSITORY}',
           '$COMMIT_SHA',
           '${_DOCKER_USER}',
           ]
-- id: 'Check push'
+- id: 'Check push to internal build cache with commit hash'
+  name: 'gcr.io/cloud-builders/gsutil'
+  entrypoint: "bash"
+  args: [
+          'google-cloud-build/ci-scripts/scripts/check_build.sh', 
+          '${_LOG_BUCKET}', 
+          '${_FLAVOR}', 
+          '$BUILD_ID'
+          ]
+- id: 'Push images to internal build cache without commit hash'
+  name: 'gcr.io/script-languages/build-container'
+  args: [
+          'bash',
+          'google-cloud-build/ci-scripts/scripts/push.sh',
+          '${_FLAVOR}',
+          '${_RELEASE_DOCKER_REPOSITORY}',
+          '""',
+          '${_BUILD_DOCKER_REPOSITORY}',
+          '""',
+          '${_DOCKER_USER}',
+          ]
+- id: 'Check  to internal build cache without commit hash'
   name: 'gcr.io/cloud-builders/gsutil'
   entrypoint: "bash"
   args: [

--- a/google-cloud-build/ci-scripts/build_master_branch.yaml
+++ b/google-cloud-build/ci-scripts/build_master_branch.yaml
@@ -51,19 +51,40 @@ steps:
           '${_KEY_RING_NAME}',
           '${_KEY_NAME}'
           ]
-- id: 'Push images to internal build cache'
+- id: 'Push images to internal build cache with commit hash'
   name: 'gcr.io/script-languages/build-container'
   args: [
           'bash',
           'google-cloud-build/ci-scripts/scripts/push.sh',
           '${_FLAVOR}',
-          '""',
+          '${_RELEASE_DOCKER_REPOSITORY}',
           '""',
           '${_BUILD_DOCKER_REPOSITORY}',
           '$COMMIT_SHA',
           '${_DOCKER_USER}',
           ]
-- id: 'Check push to internal build cache'
+- id: 'Check push to internal build cache with commit hash'
+  name: 'gcr.io/cloud-builders/gsutil'
+  entrypoint: "bash"
+  args: [
+          'google-cloud-build/ci-scripts/scripts/check_build.sh', 
+          '${_LOG_BUCKET}', 
+          '${_FLAVOR}', 
+          '$BUILD_ID'
+          ]
+- id: 'Push images to internal build cache without commit hash'
+  name: 'gcr.io/script-languages/build-container'
+  args: [
+          'bash',
+          'google-cloud-build/ci-scripts/scripts/push.sh',
+          '${_FLAVOR}',
+          '${_RELEASE_DOCKER_REPOSITORY}',
+          '""',
+          '${_BUILD_DOCKER_REPOSITORY}',
+          '""',
+          '${_DOCKER_USER}',
+          ]
+- id: 'Check  to internal build cache without commit hash'
   name: 'gcr.io/cloud-builders/gsutil'
   entrypoint: "bash"
   args: [
@@ -79,8 +100,8 @@ steps:
           'google-cloud-build/ci-scripts/scripts/push.sh',
           '${_FLAVORS}',
           '${_RELEASE_DOCKER_REPOSITORY}',
-          '$COMMIT_SHA',
           '""',
+          '${_RELEASE_DOCKER_REPOSITORY}',
           '""',
           '${_DOCKER_USER}',
           ]

--- a/google-cloud-build/ci-scripts/build_master_branch.yaml
+++ b/google-cloud-build/ci-scripts/build_master_branch.yaml
@@ -44,7 +44,6 @@ steps:
   name: 'gcr.io/cloud-builders/gcloud'
   entrypoint: bash
   args: [
-          '-x',
           'google-cloud-build/ci-scripts/scripts/decrypt.sh',
           '${_DOCKER_PASSWORD}',
           'DOCKER_PASSWORD',

--- a/google-cloud-build/ci-scripts/build_master_branch.yaml
+++ b/google-cloud-build/ci-scripts/build_master_branch.yaml
@@ -1,14 +1,24 @@
 steps:
+- id: 'Decrypt Docker password'
+  name: 'gcr.io/cloud-builders/gcloud'
+  entrypoint: bash
+  args: [
+          'google-cloud-build/ci-scripts/scripts/decrypt.sh',
+          '${_DOCKER_PASSWORD}',
+          'DOCKER_PASSWORD',
+          '${_KEY_RING_NAME}',
+          '${_KEY_NAME}'
+          ]
 - id: 'Build build-container'
   name: 'gcr.io/cloud-builders/docker'
+  entrypoint: "bash"
   args: [
-          'build', 
-          '-t', 
-          'gcr.io/script-languages/build-container', 
-          'google-cloud-build/ci-scripts/scripts/'
+          'google-cloud-build/ci-scripts/scripts/build_or_pull_build_container.sh',
+          '${_BUILD_DOCKER_REPOSITORY}',
+          '${_DOCKER_USER}'
           ]
 - id: 'Build images'
-  name: 'gcr.io/script-languages/build-container'
+  name: 'exasol/script-languages:build-container'
   args: [
           'bash', 
           'google-cloud-build/ci-scripts/scripts/build.sh', 
@@ -25,7 +35,7 @@ steps:
           "$BUILD_ID"
           ]
 - id: 'Run tests'
-  name: 'gcr.io/script-languages/build-container'
+  name: 'exasol/script-languages:build-container'
   args: [
           'bash', 
           'google-cloud-build/ci-scripts/scripts/test.sh', 
@@ -40,18 +50,8 @@ steps:
           '${_FLAVOR}', 
           '$BUILD_ID'
           ]
-- id: 'Decrypt Docker password'
-  name: 'gcr.io/cloud-builders/gcloud'
-  entrypoint: bash
-  args: [
-          'google-cloud-build/ci-scripts/scripts/decrypt.sh',
-          '${_DOCKER_PASSWORD}',
-          'DOCKER_PASSWORD',
-          '${_KEY_RING_NAME}',
-          '${_KEY_NAME}'
-          ]
 - id: 'Push images to internal build cache with commit hash'
-  name: 'gcr.io/script-languages/build-container'
+  name: 'exasol/script-languages:build-container'
   args: [
           'bash',
           'google-cloud-build/ci-scripts/scripts/push.sh',
@@ -72,7 +72,7 @@ steps:
           '$BUILD_ID'
           ]
 - id: 'Push images to internal build cache without commit hash'
-  name: 'gcr.io/script-languages/build-container'
+  name: 'exasol/script-languages:build-container'
   args: [
           'bash',
           'google-cloud-build/ci-scripts/scripts/push.sh',
@@ -93,11 +93,11 @@ steps:
           '$BUILD_ID'
           ]
 - id: 'Push images to public build cache'
-  name: 'gcr.io/script-languages/build-container'
+  name: 'exasol/script-languages:build-container'
   args: [
           'bash',
           'google-cloud-build/ci-scripts/scripts/push.sh',
-          '${_FLAVORS}',
+          '${_FLAVOR}',
           '${_RELEASE_DOCKER_REPOSITORY}',
           '""',
           '${_RELEASE_DOCKER_REPOSITORY}',

--- a/google-cloud-build/ci-scripts/build_master_branch.yaml
+++ b/google-cloud-build/ci-scripts/build_master_branch.yaml
@@ -63,7 +63,28 @@ steps:
           '$COMMIT_SHA',
           '${_DOCKER_USER}',
           ]
-- id: 'Check push'
+- id: 'Check push to internal build cache'
+  name: 'gcr.io/cloud-builders/gsutil'
+  entrypoint: "bash"
+  args: [
+          'google-cloud-build/ci-scripts/scripts/check_build.sh', 
+          '${_LOG_BUCKET}', 
+          '${_FLAVOR}', 
+          '$BUILD_ID'
+          ]
+- id: 'Push images to public build cache'
+  name: 'gcr.io/script-languages/build-container'
+  args: [
+          'bash',
+          'google-cloud-build/ci-scripts/scripts/push.sh',
+          '${_FLAVORS}',
+          '${_RELEASE_DOCKER_REPOSITORY}',
+          '$COMMIT_SHA',
+          '""',
+          '""',
+          '${_DOCKER_USER}',
+          ]
+- id: 'Check push to public build cache'
   name: 'gcr.io/cloud-builders/gsutil'
   entrypoint: "bash"
   args: [

--- a/google-cloud-build/ci-scripts/export.yaml
+++ b/google-cloud-build/ci-scripts/export.yaml
@@ -11,7 +11,6 @@ steps:
   name: 'gcr.io/cloud-builders/gcloud'
   entrypoint: bash
   args: [
-          '-x',
           'google-cloud-build/ci-scripts/scripts/decrypt.sh',
           '${_DOCKER_PASSWORD}',
           'DOCKER_PASSWORD',

--- a/google-cloud-build/ci-scripts/export.yaml
+++ b/google-cloud-build/ci-scripts/export.yaml
@@ -1,12 +1,4 @@
 steps:
-- id: 'Build build-container'
-  name: 'gcr.io/cloud-builders/docker'
-  args: [
-          'build', 
-          '-t', 
-          'gcr.io/script-languages/build-container', 
-          'google-cloud-build/ci-scripts/scripts/'
-          ]
 - id: 'Decrypt Docker password'
   name: 'gcr.io/cloud-builders/gcloud'
   entrypoint: bash
@@ -17,8 +9,16 @@ steps:
           '${_KEY_RING_NAME}',
           '${_KEY_NAME}'
           ]
+- id: 'Build build-container'
+  name: 'gcr.io/cloud-builders/docker'
+  entrypoint: "bash"
+  args: [
+          'google-cloud-build/ci-scripts/scripts/build_or_pull_build_container.sh',
+          '${_BUILD_DOCKER_REPOSITORY}',
+          '${_DOCKER_USER}'
+          ]
 - id: 'Export container'
-  name: 'gcr.io/script-languages/build-container'
+  name: 'exasol/script-languages:build-container'
   args: [
           'bash',
           'google-cloud-build/ci-scripts/scripts/export.sh',

--- a/google-cloud-build/ci-scripts/rebuild_branch.yaml
+++ b/google-cloud-build/ci-scripts/rebuild_branch.yaml
@@ -1,14 +1,24 @@
 steps:
+- id: 'Decrypt Docker password'
+  name: 'gcr.io/cloud-builders/gcloud'
+  entrypoint: bash
+  args: [
+          'google-cloud-build/ci-scripts/scripts/decrypt.sh',
+          '${_DOCKER_PASSWORD}',
+          'DOCKER_PASSWORD',
+          '${_KEY_RING_NAME}',
+          '${_KEY_NAME}'
+          ]
 - id: 'Build build-container'
   name: 'gcr.io/cloud-builders/docker'
+  entrypoint: "bash"
   args: [
-          'build', 
-          '-t', 
-          'gcr.io/script-languages/build-container', 
-          'google-cloud-build/ci-scripts/scripts/'
+          'google-cloud-build/ci-scripts/scripts/build_or_pull_build_container.sh',
+          '${_BUILD_DOCKER_REPOSITORY}',
+          '${_DOCKER_USER}'
           ]
 - id: 'Build images'
-  name: 'gcr.io/script-languages/build-container'
+  name: 'exasol/script-languages:build-container'
   args: [
           'bash', 
           'google-cloud-build/ci-scripts/scripts/build.sh', 
@@ -25,7 +35,7 @@ steps:
           "$BUILD_ID"
           ]
 - id: 'Run tests'
-  name: 'gcr.io/script-languages/build-container'
+  name: 'exasol/script-languages:build-container'
   args: [
           'bash', 
           'google-cloud-build/ci-scripts/scripts/test.sh', 
@@ -40,29 +50,40 @@ steps:
           '${_FLAVOR}', 
           '$BUILD_ID'
           ]
-- id: 'Decrypt Docker password'
-  name: 'gcr.io/cloud-builders/gcloud'
-  entrypoint: bash
-  args: [
-          'google-cloud-build/ci-scripts/scripts/decrypt.sh',
-          '${_BUILD_DOCKER_PASSWORD}',
-          'DOCKER_PASSWORD',
-          '${_KEY_RING_NAME}',
-          '${_KEY_NAME}'
-          ]
-- id: 'Push images to internal build cache'
-  name: 'gcr.io/script-languages/build-container'
+- id: 'Push images to internal build cache with commit hash'
+  name: 'exasol/script-languages:build-container'
   args: [
           'bash',
           'google-cloud-build/ci-scripts/scripts/push.sh',
           '${_FLAVOR}',
-          '""',
+          '${_RELEASE_DOCKER_REPOSITORY}',
           '""',
           '${_BUILD_DOCKER_REPOSITORY}',
           '$COMMIT_SHA',
-          '${_BUILD_DOCKER_USER}',
+          '${_DOCKER_USER}',
           ]
-- id: 'Check push'
+- id: 'Check push to internal build cache with commit hash'
+  name: 'gcr.io/cloud-builders/gsutil'
+  entrypoint: "bash"
+  args: [
+          'google-cloud-build/ci-scripts/scripts/check_build.sh', 
+          '${_LOG_BUCKET}', 
+          '${_FLAVOR}', 
+          '$BUILD_ID'
+          ]
+- id: 'Push images to internal build cache without commit hash'
+  name: 'exasol/script-languages:build-container'
+  args: [
+          'bash',
+          'google-cloud-build/ci-scripts/scripts/push.sh',
+          '${_FLAVOR}',
+          '${_RELEASE_DOCKER_REPOSITORY}',
+          '""',
+          '${_BUILD_DOCKER_REPOSITORY}',
+          '""',
+          '${_DOCKER_USER}',
+          ]
+- id: 'Check  to internal build cache without commit hash'
   name: 'gcr.io/cloud-builders/gsutil'
   entrypoint: "bash"
   args: [

--- a/google-cloud-build/ci-scripts/rebuild_branch.yaml
+++ b/google-cloud-build/ci-scripts/rebuild_branch.yaml
@@ -44,7 +44,6 @@ steps:
   name: 'gcr.io/cloud-builders/gcloud'
   entrypoint: bash
   args: [
-          '-x',
           'google-cloud-build/ci-scripts/scripts/decrypt.sh',
           '${_BUILD_DOCKER_PASSWORD}',
           'DOCKER_PASSWORD',

--- a/google-cloud-build/ci-scripts/release.yaml
+++ b/google-cloud-build/ci-scripts/release.yaml
@@ -1,11 +1,21 @@
 steps:
+- id: 'Decrypt Docker password'
+  name: 'gcr.io/cloud-builders/gcloud'
+  entrypoint: bash
+  args: [
+          'google-cloud-build/ci-scripts/scripts/decrypt.sh',
+          '${_DOCKER_PASSWORD}',
+          'DOCKER_PASSWORD',
+          '${_KEY_RING_NAME}',
+          '${_KEY_NAME}'
+          ]
 - id: 'Build build-container'
   name: 'gcr.io/cloud-builders/docker'
+  entrypoint: "bash"
   args: [
-          'build', 
-          '-t', 
-          'gcr.io/script-languages/build-container', 
-          'google-cloud-build/ci-scripts/scripts/'
+          'google-cloud-build/ci-scripts/scripts/build_or_pull_build_container.sh',
+          '${_BUILD_DOCKER_REPOSITORY}',
+          '${_DOCKER_USER}'
           ]
 - id: 'Decrypt Github Token'
   name: 'gcr.io/cloud-builders/gcloud'
@@ -18,7 +28,7 @@ steps:
           '${_KEY_NAME}'
           ]
 - id: 'Export container'
-  name: 'gcr.io/script-languages/build-container'
+  name: 'exasol/script-languages:build-container'
   args: [
           'bash',
           'google-cloud-build/ci-scripts/scripts/export.sh',
@@ -47,7 +57,7 @@ steps:
           '${_CONTAINER_BUCKET}/exports/$COMMIT_SHA/'
           ]
 - id: 'Create Github Release'
-  name: 'gcr.io/script-languages/build-container'
+  name: 'exasol/script-languages:build-container'
   args: [
           'bash',
           'google-cloud-build/ci-scripts/scripts/create_github_release.sh', 

--- a/google-cloud-build/ci-scripts/release.yaml
+++ b/google-cloud-build/ci-scripts/release.yaml
@@ -57,18 +57,6 @@ steps:
           '.build_output/cache/exports/*',
           '${_CONTAINER_BUCKET}/exports/$COMMIT_SHA/'
           ]
-- id: 'Push images to public build cache'
-  name: 'gcr.io/script-languages/build-container'
-  args: [
-          'bash',
-          'google-cloud-build/ci-scripts/scripts/push.sh',
-          '${_FLAVORS}',
-          '${_BUILD_DOCKER_REPOSITORY}',
-          '$COMMIT_SHA',
-          '""',
-          '""',
-          '${_DOCKER_USER}',
-          ]
 - id: 'Check push'
   name: 'gcr.io/cloud-builders/gsutil'
   entrypoint: "bash"

--- a/google-cloud-build/ci-scripts/release.yaml
+++ b/google-cloud-build/ci-scripts/release.yaml
@@ -53,6 +53,7 @@ steps:
 - id: 'Upload exported container'
   name: 'gcr.io/cloud-builders/gsutil'
   args: [
+          '-m',
           'cp',
           '.build_output/cache/exports/*',
           '${_CONTAINER_BUCKET}/exports/$COMMIT_SHA/'

--- a/google-cloud-build/ci-scripts/release.yaml
+++ b/google-cloud-build/ci-scripts/release.yaml
@@ -7,22 +7,10 @@ steps:
           'gcr.io/script-languages/build-container', 
           'google-cloud-build/ci-scripts/scripts/'
           ]
-- id: 'Decrypt Docker password'
-  name: 'gcr.io/cloud-builders/gcloud'
-  entrypoint: bash
-  args: [
-          '-x',
-          'google-cloud-build/ci-scripts/scripts/decrypt.sh',
-          '${_DOCKER_PASSWORD}',
-          'DOCKER_PASSWORD',
-          '${_KEY_RING_NAME}',
-          '${_KEY_NAME}'
-          ]
 - id: 'Decrypt Github Token'
   name: 'gcr.io/cloud-builders/gcloud'
   entrypoint: bash
   args: [
-          '-x',
           'google-cloud-build/ci-scripts/scripts/decrypt.sh',
           '${_GITHUB_TOKEN}',
           'GITHUB_TOKEN',

--- a/google-cloud-build/ci-scripts/release.yaml
+++ b/google-cloud-build/ci-scripts/release.yaml
@@ -58,15 +58,6 @@ steps:
           '.build_output/cache/exports/*',
           '${_CONTAINER_BUCKET}/exports/$COMMIT_SHA/'
           ]
-- id: 'Check push'
-  name: 'gcr.io/cloud-builders/gsutil'
-  entrypoint: "bash"
-  args: [
-          'google-cloud-build/ci-scripts/scripts/check_build.sh', 
-          '${_LOG_BUCKET}', 
-          '${_FLAVOR}', 
-          '$BUILD_ID'
-          ]
 - id: 'Create Github Release'
   name: 'gcr.io/script-languages/build-container'
   args: [

--- a/google-cloud-build/ci-scripts/scripts/build.sh
+++ b/google-cloud-build/ci-scripts/scripts/build.sh
@@ -13,5 +13,11 @@ touch /workspace/build-status.txt
 COMMAND="./exaslct build --flavor-path "flavors/$FLAVOR" --workers 7 $ADDITIONAL_ARGUMENTS"
 echo "Executing Command: $COMMAND"
 $COMMAND || echo "fail" > /workspace/build-status.txt
+echo
+echo "=========================================================="
+echo "Printing docker images"
+echo "=========================================================="
+echo
+docker images
 
 # TODO use internal cache without commit hash as source and produce release target except for master branch builds

--- a/google-cloud-build/ci-scripts/scripts/build.sh
+++ b/google-cloud-build/ci-scripts/scripts/build.sh
@@ -9,10 +9,20 @@ if [ "$REBUILD" == "True" ]
 then
   ADDITIONAL_ARGUMENTS="--force-rebuild"
 fi
+BUILD_PARAMETER="--no-shortcut-build"
+SYSTEM_PARAMETER="--workers 7"
+if [ -f /workspace/build-status.txt ]
+then
+  rm /workspace/build-status.txt
+fi
 touch /workspace/build-status.txt
-COMMAND="./exaslct build --flavor-path "flavors/$FLAVOR" --workers 7 $ADDITIONAL_ARGUMENTS"
+COMMAND="./exaslct build --flavor-path "flavors/$FLAVOR" $BUILD_PARAMETER $ADDITIONAL_ARGUMENTS $SYSTEM_PARAMETER"
 echo "Executing Command: $COMMAND"
-$COMMAND || echo "fail" > /workspace/build-status.txt
+$COMMAND || echo "fail" >> /workspace/build-status.txt
+echo
+COMMAND="./exaslct build-test-container $BUILD_PARAMETER $ADDITIONAL_ARGUMENTS $SYSTEM_PARAMETER"
+echo "Executing Command: $COMMAND"
+$COMMAND || echo "fail" >> /workspace/build-status.txt
 echo
 echo "=========================================================="
 echo "Printing docker images"

--- a/google-cloud-build/ci-scripts/scripts/build.sh
+++ b/google-cloud-build/ci-scripts/scripts/build.sh
@@ -28,6 +28,6 @@ echo "=========================================================="
 echo "Printing docker images"
 echo "=========================================================="
 echo
-docker images
+docker images | grep exa
 
 # TODO use internal cache without commit hash as source and produce release target except for master branch builds

--- a/google-cloud-build/ci-scripts/scripts/build.sh
+++ b/google-cloud-build/ci-scripts/scripts/build.sh
@@ -13,3 +13,5 @@ touch /workspace/build-status.txt
 COMMAND="./exaslct build --flavor-path "flavors/$FLAVOR" --workers 7 $ADDITIONAL_ARGUMENTS"
 echo "Executing Command: $COMMAND"
 $COMMAND || echo "fail" > /workspace/build-status.txt
+
+# TODO use internal cache without commit hash as source and produce release target except for master branch builds

--- a/google-cloud-build/ci-scripts/scripts/build.sh
+++ b/google-cloud-build/ci-scripts/scripts/build.sh
@@ -20,7 +20,7 @@ COMMAND="./exaslct build --flavor-path "flavors/$FLAVOR" $BUILD_PARAMETER $ADDIT
 echo "Executing Command: $COMMAND"
 $COMMAND || echo "fail" >> /workspace/build-status.txt
 echo
-COMMAND="./exaslct build-test-container $BUILD_PARAMETER $ADDITIONAL_ARGUMENTS $SYSTEM_PARAMETER"
+COMMAND="./exaslct build-test-container $ADDITIONAL_ARGUMENTS $SYSTEM_PARAMETER"
 echo "Executing Command: $COMMAND"
 $COMMAND || echo "fail" >> /workspace/build-status.txt
 echo

--- a/google-cloud-build/ci-scripts/scripts/build_or_pull_build_container.sh
+++ b/google-cloud-build/ci-scripts/scripts/build_or_pull_build_container.sh
@@ -1,0 +1,53 @@
+#!/bin/bash
+set -o errexit
+set -o nounset
+set -o pipefail
+DOCKER_USER=$2
+DOCKER_PASSWORD="$(cat secrets/DOCKER_PASSWORD)"
+echo "$DOCKER_PASSWORD" | docker login --username "$DOCKER_USER" --password-stdin
+
+#set -x
+
+DOCKER_REPOSITORY=$1
+DOCKERFILE_HASH=$(cat google-cloud-build/ci-scripts/scripts/Dockerfile | shasum | cut -f 1 -d " ")
+TAG_NAME="build-container-$DOCKERFILE_HASH"
+TAG_NAME_SHORT="${TAG_NAME:0:127}"
+IMAGE_NAME="$DOCKER_REPOSITORY:$TAG_NAME_SHORT"
+
+echo
+echo "=========================================================="
+echo "Try to pull image $IMAGE_NAME"
+echo "=========================================================="
+echo
+if ! docker pull "$IMAGE_NAME"
+then
+  echo
+  echo "=========================================================="
+  echo "Pull failed going to build image $IMAGE_NAME"
+  echo "=========================================================="
+  echo
+  docker build -t "$IMAGE_NAME" google-cloud-build/ci-scripts/scripts/
+
+  echo
+  echo "=========================================================="
+  echo "Push image $IMAGE_NAME"
+  echo "=========================================================="
+  echo
+  docker push "$IMAGE_NAME"
+fi
+
+LOCAL_IMAGE_NAME="exasol/script-languages:build-container"
+echo
+echo "=========================================================="
+echo "Rename image $IMAGE_NAME" to "$LOCAL_IMAGE_NAME"
+echo "=========================================================="
+echo
+docker tag "$IMAGE_NAME" "$LOCAL_IMAGE_NAME"
+
+echo
+echo "=========================================================="
+echo "Printing docker images"
+echo "=========================================================="
+echo
+docker images | grep exa
+

--- a/google-cloud-build/ci-scripts/scripts/check_build.sh
+++ b/google-cloud-build/ci-scripts/scripts/check_build.sh
@@ -13,6 +13,13 @@ fi
 DATETIME=$(cat $DATETIME_FILE)
 BUCKET="$LOG_BUCKET/$FLAVOR/${DATETIME}_${BUILD_ID}/"
 BUILD_OUTPUT_PATH=".build_output/jobs"
+echo
+echo "=========================================================="
+echo "Printing docker images"
+echo "=========================================================="
+echo
+docker images
+echo
 echo "=========================================================="
 echo "Copy $BUILD_OUTPUT_PATH to $BUCKET"
 echo "=========================================================="

--- a/google-cloud-build/ci-scripts/scripts/check_build.sh
+++ b/google-cloud-build/ci-scripts/scripts/check_build.sh
@@ -17,7 +17,7 @@ echo "=========================================================="
 echo "Copy $BUILD_OUTPUT_PATH to $BUCKET"
 echo "=========================================================="
 echo
-gsutil rsync -C -x exports -r "$BUILD_OUTPUT_PATH" "$BUCKET" 2>&1 | tee rync.log || echo "fail" > /workspace/build-status.txt 
+gsutil -m rsync -C -x exports -r "$BUILD_OUTPUT_PATH" "$BUCKET" 2>&1 | tee rync.log || echo "fail" > /workspace/build-status.txt 
 echo
 echo "=========================================================="
 echo "Copy rsync.log to $BUCKET/rsync.log"

--- a/google-cloud-build/ci-scripts/scripts/check_build.sh
+++ b/google-cloud-build/ci-scripts/scripts/check_build.sh
@@ -25,6 +25,6 @@ echo "Copy rsync.log to $BUCKET/rsync.log"
 echo "=========================================================="
 echo
 gsutil cp rync.log "$BUCKET"
-if [[ $(< /workspace/build-status.txt) == "fail" ]]; then
+if [[ grep fail /workspace/build-status.txt ]]; then
 	exit 1
 fi

--- a/google-cloud-build/ci-scripts/scripts/check_build.sh
+++ b/google-cloud-build/ci-scripts/scripts/check_build.sh
@@ -15,12 +15,6 @@ BUCKET="$LOG_BUCKET/$FLAVOR/${DATETIME}_${BUILD_ID}/"
 BUILD_OUTPUT_PATH=".build_output/jobs"
 echo
 echo "=========================================================="
-echo "Printing docker images"
-echo "=========================================================="
-echo
-docker images
-echo
-echo "=========================================================="
 echo "Copy $BUILD_OUTPUT_PATH to $BUCKET"
 echo "=========================================================="
 echo

--- a/google-cloud-build/ci-scripts/scripts/check_build.sh
+++ b/google-cloud-build/ci-scripts/scripts/check_build.sh
@@ -25,6 +25,7 @@ echo "Copy rsync.log to $BUCKET/rsync.log"
 echo "=========================================================="
 echo
 gsutil cp rync.log "$BUCKET"
-if [[ grep fail /workspace/build-status.txt ]]; then
+if grep fail /workspace/build-status.txt
+then
 	exit 1
 fi

--- a/google-cloud-build/ci-scripts/scripts/check_build.sh
+++ b/google-cloud-build/ci-scripts/scripts/check_build.sh
@@ -11,8 +11,18 @@ then
 	date --utc +%Y%m%d_%H%M%S > "$DATETIME_FILE"
 fi
 DATETIME=$(cat $DATETIME_FILE)
-BUCKET="$LOG_BUCKET/build_output/$FLAVOR/${DATETIME}_${BUILD_ID}/"
-gsutil rsync -C -x exports -r .build_output/jobs "$BUCKET" &> rync.log || echo "fail" > /workspace/build-status.txt 
+BUCKET="$LOG_BUCKET/$FLAVOR/${DATETIME}_${BUILD_ID}/"
+BUILD_OUTPUT_PATH=".build_output/jobs"
+echo "=========================================================="
+echo "Copy $BUILD_OUTPUT_PATH to $BUCKET"
+echo "=========================================================="
+echo
+gsutil rsync -C -x exports -r "$BUILD_OUTPUT_PATH" "$BUCKET" 2>&1 | tee rync.log || echo "fail" > /workspace/build-status.txt 
+echo
+echo "=========================================================="
+echo "Copy rsync.log to $BUCKET/rsync.log"
+echo "=========================================================="
+echo
 gsutil cp rync.log "$BUCKET"
 if [[ $(< /workspace/build-status.txt) == "fail" ]]; then
 	exit 1

--- a/google-cloud-build/ci-scripts/scripts/check_build.sh
+++ b/google-cloud-build/ci-scripts/scripts/check_build.sh
@@ -12,7 +12,7 @@ then
 fi
 DATETIME=$(cat $DATETIME_FILE)
 BUCKET="$LOG_BUCKET/build_output/$FLAVOR/${DATETIME}_${BUILD_ID}/"
-gsutil rsync -C -x exports -r .build_output "$BUCKET" &> rync.log || echo "fail" > /workspace/build-status.txt 
+gsutil rsync -C -x exports -r .build_output/jobs "$BUCKET" &> rync.log || echo "fail" > /workspace/build-status.txt 
 gsutil cp rync.log "$BUCKET"
 if [[ $(< /workspace/build-status.txt) == "fail" ]]; then
 	exit 1

--- a/google-cloud-build/ci-scripts/scripts/push.sh
+++ b/google-cloud-build/ci-scripts/scripts/push.sh
@@ -31,4 +31,4 @@ echo "=========================================================="
 echo "Printing docker images"
 echo "=========================================================="
 echo
-docker images
+docker images | grep exa

--- a/google-cloud-build/ci-scripts/scripts/push.sh
+++ b/google-cloud-build/ci-scripts/scripts/push.sh
@@ -12,10 +12,20 @@ generate_flavor_options "$1"
 shift 1
 generate_source_target_docker_options $SCRIPT_DIR $*
 
+PUSH_PARAMETER="--push-all --force-push"
+SYSTEM_PARAMETER="--workers 7"
+if [ -f /workspace/build-status.txt ]
+then
+  rm /workspace/build-status.txt
+fi
 touch /workspace/build-status.txt
-COMMAND="./exaslct push $SOURCE_OPTIONS $TARGET_OPTIONS --push-all --force-push $FLAVOR_OPTIONS --workers 7"
+COMMAND="./exaslct push $FLAVOR_OPTIONS $SOURCE_OPTIONS $TARGET_OPTIONS $PUSH_PARAMETER $SYSTEM_PARAMETER"
 echo "Executing Command: $COMMAND"
-bash -c "$COMMAND" || echo "fail" > /workspace/build-status.txt
+bash -c "$COMMAND" || echo "fail" >> /workspace/build-status.txt
+echo
+COMMAND="./exaslct push $FLAVOR_OPTIONS $SOURCE_OPTIONS $TARGET_OPTIONS $PUSH_PARAMETER $SYSTEM_PARAMETER"
+echo "Executing Command: $COMMAND"
+bash -c "$COMMAND" || echo "fail" >> /workspace/build-status.txt
 echo
 echo "=========================================================="
 echo "Printing docker images"

--- a/google-cloud-build/ci-scripts/scripts/push.sh
+++ b/google-cloud-build/ci-scripts/scripts/push.sh
@@ -16,3 +16,9 @@ touch /workspace/build-status.txt
 COMMAND="./exaslct push $SOURCE_OPTIONS $TARGET_OPTIONS --push-all --force-push $FLAVOR_OPTIONS --workers 7"
 echo "Executing Command: $COMMAND"
 bash -c "$COMMAND" || echo "fail" > /workspace/build-status.txt
+echo
+echo "=========================================================="
+echo "Printing docker images"
+echo "=========================================================="
+echo
+docker images

--- a/google-cloud-build/ci-scripts/scripts/test.sh
+++ b/google-cloud-build/ci-scripts/scripts/test.sh
@@ -9,4 +9,10 @@ then
 else
   touch /workspace/build-status.txt
   ./exaslct run-db-test --flavor-path "flavors/$FLAVOR"  --workers 7 || echo "fail" > /workspace/build-status.txt
+echo
+echo "=========================================================="
+echo "Printing docker images"
+echo "=========================================================="
+echo
+docker images
 fi

--- a/google-cloud-build/ci-scripts/scripts/test.sh
+++ b/google-cloud-build/ci-scripts/scripts/test.sh
@@ -14,5 +14,5 @@ echo "=========================================================="
 echo "Printing docker images"
 echo "=========================================================="
 echo
-docker images
+docker images | grep exa
 fi

--- a/google-cloud-build/ci-scripts/test_branch_exaslct.yaml
+++ b/google-cloud-build/ci-scripts/test_branch_exaslct.yaml
@@ -27,12 +27,12 @@ steps:
           'run_exaslct_test.sh',
           'exaslct_src/test/test_hash_temp_dir.py'
         ]
-- id: 'Test exaslct test_generate_alter_session.py'
+- id: 'Test exaslct test_generate_language_activation.py'
   name: 'gcr.io/script-languages/build-container'
   args: [
           'bash', 
           'run_exaslct_test.sh',
-          'exaslct_src/test/test_generate_alter_session.py'
+          'exaslct_src/test/test_generate_language_activation.py'
         ]
 - id: 'Test exaslct test_docker_build.py'
   name: 'gcr.io/script-languages/build-container'

--- a/google-cloud-build/download_config.sh
+++ b/google-cloud-build/download_config.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+set -o errexit
+set -o nounset
+set -o pipefail
+
+env_file=".env/env.yaml"
+SCRIPT_DIR="$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")"
+PROJECT=$1
+CONFIG_BUCKET_NAME=$2
+CONFIG_BUCKET="gs://$CONFIG_BUCKET_NAME/.env"
+gcloud config set project "$PROJECT"
+gsutil cp -r "$CONFIG_BUCKET" "file://." 

--- a/google-cloud-build/download_config.sh
+++ b/google-cloud-build/download_config.sh
@@ -9,4 +9,4 @@ PROJECT=$1
 CONFIG_BUCKET_NAME=$2
 CONFIG_BUCKET="gs://$CONFIG_BUCKET_NAME/.env"
 gcloud config set project "$PROJECT"
-gsutil cp -r "$CONFIG_BUCKET" "file://." 
+gsutil -m cp -r "$CONFIG_BUCKET" "file://." 

--- a/google-cloud-build/github-status-notifications/index.js
+++ b/google-cloud-build/github-status-notifications/index.js
@@ -44,8 +44,10 @@ exports.githubBuildStatusNotification = (event, context) => {
     context+='performance-test/'+flavor;
   }else if(jobType=='release'){
     context+='release';
+  }else if(jobType=='exaslct-tests'){
+    context+='exaslct-tests';
   }else{
-    console.error("Flavor not defined")
+    console.error("Job type not defined")
   }
 
   url='https://console.cloud.google.com/cloud-build/builds/'+buildId+'?project='+gcloudProject

--- a/google-cloud-build/setup-scripts/copy_config.sh
+++ b/google-cloud-build/setup-scripts/copy_config.sh
@@ -5,4 +5,4 @@ set -o pipefail
 
 env_file=".env/env.yaml"
 CONFIG_BUCKET=$(cat "$env_file" | yq -r .config_bucket)
-gsutil cp -r "file://.env" "$CONFIG_BUCKET"
+gsutil -m cp -r "file://.env" "$CONFIG_BUCKET"

--- a/google-cloud-build/triggers/build_branch.json.jinja2
+++ b/google-cloud-build/triggers/build_branch.json.jinja2
@@ -19,7 +19,7 @@
     {% elif build_mode == "build" %}
     "branchName": "^(feature|bug|enhancement|refactoring|ci)/.*"
     {% elif build_mode == "release" %} 
-    "branchName": "^(develop|master)$"
+    "branchName": "^(develop|master|ci-release-test/.*)$"
     {% endif %}
   },
   {% if build_mode == "rebuild"  %}

--- a/google-cloud-build/triggers/build_branch.json.jinja2
+++ b/google-cloud-build/triggers/build_branch.json.jinja2
@@ -44,8 +44,9 @@
     "_KEY_RING_NAME": "{{ key_ring_name }}",
     "_KEY_NAME": "{{ key_name }}",
     "_BUILD_DOCKER_REPOSITORY": "{{ build_docker_repository }}",
-    "_BUILD_DOCKER_USER": "{{ docker_user }}",
-    "_BUILD_DOCKER_PASSWORD": "{{ docker_password }}",
+    "_RELEASE_DOCKER_REPOSITORY": "{{ release_docker_repository }}",
+    "_DOCKER_USER": "{{ docker_user }}",
+    "_DOCKER_PASSWORD": "{{ docker_password }}",
     "_GITHUB_TOKEN": "{{ github_token }}",
     "_GITHUB_USER_NAME": "{{ github_user_name }}",
     "_GITHUB_REPOSITORY": "{{ github_repository }}",
@@ -54,7 +55,7 @@
   {% if build_mode == "build" %}
   "includedFiles": [
     "docker_db_config/**",
-    "src/**",
+    "exaudfclient/**",
     "exaslct_src/**",
     "flavors/{{ flavor }}/**",
     "ext/**",
@@ -64,5 +65,9 @@
     "Pipfile"
   ],
   {% endif %}
-  "filename": "google-cloud-build/ci-scripts/build_branch.yaml"
+  {% if build_mode == "release" %}
+  "filename": "google-cloud-build/ci-scripts/build_master_branch.yaml" 
+  {% else %}
+  "filename": "google-cloud-build/ci-scripts/build_branch.yaml" 
+  {% endif %}
 }

--- a/google-cloud-build/triggers/build_branch.json.jinja2
+++ b/google-cloud-build/triggers/build_branch.json.jinja2
@@ -23,11 +23,11 @@
     {% endif %}
   },
   {% if build_mode == "rebuild"  %}
-  "description": "Rebuild branch {{ flavor }}",
+  "description": "Rebuild branch {{ flavor }} {{ github_user_name }}-{{ github_repository }}",
   {% elif build_mode == "build" %}
-  "description": "Build branch {{ flavor }}",
+  "description": "Build branch {{ flavor }} {{ github_user_name }}-{{ github_repository }}",
   {% elif build_mode == "release" %} 
-  "description": "Build release {{ flavor }}",
+  "description": "Build release {{ flavor }} {{ github_user_name }}-{{ github_repository }}",
   {% endif %}
   "substitutions": {
     "_JOB_ID": "{{ job_id }}", 

--- a/google-cloud-build/triggers/build_pull_request.json.jinja2
+++ b/google-cloud-build/triggers/build_pull_request.json.jinja2
@@ -19,7 +19,7 @@
   },
   "includedFiles": [
     "docker_db_config/**",
-    "src/**",
+    "exaudfclient/**",
     "exaslct_src/**",
     "flavors/{{ flavor }}/**",
     "ext/**",

--- a/google-cloud-build/triggers/build_pull_request.json.jinja2
+++ b/google-cloud-build/triggers/build_pull_request.json.jinja2
@@ -8,7 +8,7 @@
     "repoName": "github_{{ github_user_name }}_{{ github_repository }}",
     "branchName": "^pull_request/.*"
   },
-  "description": "Build pull request {{ flavor }}",
+  "description": "Build pull request {{ flavor }} {{ github_user_name }}-{{ github_repository }}",
   "substitutions": {
     "_JOB_ID": "{{ job_id }}",
     "_FLAVOR": "{{ flavor }}",

--- a/google-cloud-build/triggers/export.json.jinja2
+++ b/google-cloud-build/triggers/export.json.jinja2
@@ -8,7 +8,7 @@
     "repoName": "github_{{ github_user_name }}_{{ github_repository }}",
     "branchName": ".*"
   }, 
-  "description": "Export {{ flavor }}",
+  "description": "Export {{ flavor }} {{ github_user_name }}-{{ github_repository }}",
   "substitutions": {
     "_JOB_ID": "{{ job_id }}",
     "_FLAVOR": "{{ flavor }}",

--- a/google-cloud-build/triggers/release.json.jinja2
+++ b/google-cloud-build/triggers/release.json.jinja2
@@ -17,9 +17,9 @@
     {% endif %}
   }, 
   {% if debug == false  %}
-  "description": "Release",
+  "description": "Release {{ github_user_name }}-{{ github_repository }}",
   {% else %}
-  "description": "Release (Debug)",
+  "description": "Release (Debug) {{ github_user_name }}-{{ github_repository }}",
   {% endif %}
   "substitutions": {
     "_JOB_ID": "{{ job_id }}",

--- a/google-cloud-build/triggers/release.json.jinja2
+++ b/google-cloud-build/triggers/release.json.jinja2
@@ -13,7 +13,7 @@
     {% if debug == false  %}
     "tagName": "^(([^c][^i][^/]|[^c]i.|c[^i].|ci[^/]).*|..$)"
     {% else  %}
-    "branchName": "^ci/.*"
+    "branchName": "^ci-release-test/.*"
     {% endif %}
   }, 
   {% if debug == false  %}

--- a/google-cloud-build/triggers/test_branch_exaslct.json.jinja2
+++ b/google-cloud-build/triggers/test_branch_exaslct.json.jinja2
@@ -10,7 +10,7 @@
   "description": "Exaslct Test branch",
   "substitutions": {
     "_JOB_ID": "{{ job_id }}", 
-    "_JOB_TYPE": "Test exaslct",
+    "_JOB_TYPE": "exaslct-tests",
     "_GITHUB_USER_NAME": "{{ github_user_name }}",
     "_GITHUB_REPOSITORY": "{{ github_repository }}"
   },

--- a/google-cloud-build/update_triggers.sh
+++ b/google-cloud-build/update_triggers.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+set -o errexit
+set -o nounset
+set -o pipefail
+
+env_file=".env/env.yaml"
+SCRIPT_DIR="$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")"
+PROJECT=$(cat "$env_file" | yq -r .gcloud_project_name)
+gcloud config set project "$PROJECT"
+$SCRIPT_DIR/setup-scripts/update_triggers.sh
+$SCRIPT_DIR/setup-scripts/copy_config.sh


### PR DESCRIPTION
Trigger Changes:
- Master branch and release trigger react on ci-release-test
- Fix trigger directories for build jobs
- Add repo name to the trigger name

Build Cache Changes:
- Move push to public build cache into the build jobs for the master branch
- All build trigger push to internal build cache with commit hash and without
- Pull build-container if possible or build and push it with build_or_pull_build_container.sh
- If the test-container not available in the public build cache, then build and push it to the build caches

Exaslct Tests Change:
- Fix test_branch_exaslct.yaml
- Fix github status name for exaslct tests

Additional Changes:
- Add scripts download_config.sh and update_triggers.sh
- Use parallel copy with gsutils
- Build steps which use docker, now list the local docker images at the end
- Move job build output to subdirectory in exaslct output directory to not copy the cache during check_build.sh
