### PR TITLE
Improve error message of language implementations in the UDFClient

### DIFF
--- a/exaudfclient/base/exaudflib/exaudflib.cc
+++ b/exaudfclient/base/exaudflib/exaudflib.cc
@@ -1692,7 +1692,8 @@ unsigned int handle_error(zmq::socket_t& socket, std::string socket_name, SWIGVM
     DBG_STREAM_MSG(cerr,"### handle error in '" << socket_name << " (" << ::getppid() << ',' << ::getpid() << "): " << msg);
     try{
         if(vm!=nullptr && shutdown_vm){
-            vm->shutdown();
+            vm->exception_msg = "";
+            vm->shutdown(); // Calls cleanup
             if (vm->exception_msg.size()>0) {
                 PRINT_ERROR_MESSAGE(cerr,"F-UDF.CL.L-110","### Caught error in vm->shutdown '" << socket_name << " (" << ::getppid() << ',' << ::getpid() << "): " << vm->exception_msg);
                 msg ="F-UDF.CL.L-111: Caught exception\n\n"+msg+"\n\n and caught another exception during cleanup\n\n"+vm->exception_msg;

--- a/exaudfclient/base/exaudflib/exaudflib.cc
+++ b/exaudfclient/base/exaudflib/exaudflib.cc
@@ -1840,7 +1840,7 @@ reinit:
 
     if (!send_init(socket, socket_name)) {
         if (!get_remote_client() && exchandler.exthrowed) {
-            return handle_error(socket, socket_name, vm, exchandler.exmsg, false);
+            return handle_error(socket, socket_name, vm, "F-UDF.CL.L-128: "+exchandler.exmsg, false);
         }else{
             goto reinit;
         }
@@ -1867,7 +1867,7 @@ reinit:
             return handle_error(socket, socket_name, vm, "F-UDF.CL.L-123: Unknown or unsupported VM type", false);
         }
         if (vm->exception_msg.size()>0) {
-            return handle_error(socket, socket_name, vm, vm->exception_msg.c_str(), false);
+            return handle_error(socket, socket_name, vm, "F-UDF.CL.L-129: "+vm->exception_msg, false);
         }
         shutdown_vm_in_case_of_error = true;
         use_zmq_socket_locks = vm->useZmqSocketLocks();
@@ -1907,7 +1907,7 @@ reinit:
                             break;
                     }
                     if (vm->exception_msg.size()>0) {
-                        return handle_error(socket, socket_name, vm, vm->exception_msg,true);
+                        return handle_error(socket, socket_name, vm, "F-UDF.CL.L-130: "+vm->exception_msg,true);
                     }
 
                     if (vm->calledUndefinedSingleCall.size()>0) {
@@ -1929,7 +1929,7 @@ reinit:
                 while(!vm->run_())
                 {
                     if (vm->exception_msg.size()>0) {
-                        return handle_error(socket, socket_name, vm, vm->exception_msg,true);
+                        return handle_error(socket, socket_name, vm, "F-UDF.CL.L-131: "+vm->exception_msg,true);
                     }
                 }
                 if (!send_done(socket))
@@ -1941,7 +1941,7 @@ reinit:
         {
             vm->shutdown();
             if (vm->exception_msg.size()>0) {
-                return handle_error(socket, socket_name, vm, vm->exception_msg,false);
+                return handle_error(socket, socket_name, vm, "F-UDF.CL.L-132: "+vm->exception_msg,false);
             }
         }
         send_finished(socket);

--- a/exaudfclient/base/exaudflib/exaudflib.cc
+++ b/exaudfclient/base/exaudflib/exaudflib.cc
@@ -97,7 +97,7 @@ static void external_process_check()
     if (remote_client) return;
     if (::access(socket_name_file, F_OK) != 0) {
         ::sleep(1); // give me a chance to die with my parent process
-        PRINT_ERROR_MESSAGE(cerr,"F-UDF.CL.L-1","exaudfclient aborting ... cannot access socket file " << socket_name_str+6 << ".");
+        PRINT_ERROR_MESSAGE(cerr,"F-UDF.CL.LIB-1000","exaudfclient aborting ... cannot access socket file " << socket_name_str+6 << ".");
         DBG_STREAM_MSG(cerr,"### SWIGVM aborting with name '" << socket_name_str << "' (" << ::getppid() << ',' << ::getpid() << ')');
         ::abort();
     }
@@ -117,7 +117,7 @@ void check_parent_pid(){
     // will be adopted by another process
     if(first_ppid!=new_ppid){ 
         ::sleep(1); // give me a chance to die with my parent process
-        PRINT_ERROR_MESSAGE(cerr,"F-UDF.CL.L-2","exaudfclient aborting " << socket_name_str << " ... current parent pid " << new_ppid << " different to first parent pid " << first_ppid << "." );
+        PRINT_ERROR_MESSAGE(cerr,"F-UDF.CL.LIB-1001","exaudfclient aborting " << socket_name_str << " ... current parent pid " << new_ppid << " different to first parent pid " << first_ppid << "." );
         DBG_STREAM_MSG(cerr,"### SWIGVM aborting with name '" << socket_name_str << "' (" << ::getppid() << ',' << ::getpid() << ')');
         ::unlink(socket_name_file);
         ::abort();
@@ -354,7 +354,7 @@ bool send_init(zmq::socket_t &socket, const string client_name)
     exascript_client *req = request.mutable_client();
     req->set_client_name(client_name);
     if (!request.SerializeToString(&output_buffer)) {
-        exchandler.setException("F-UDF.CL.L-3: Communication error: failed to serialize data");
+        exchandler.setException("F-UDF.CL.LIB-1002: Communication error: failed to serialize data");
         return false;
     }
     zmq::message_t zmsg((void*)output_buffer.c_str(), output_buffer.length(), NULL, NULL);
@@ -365,7 +365,7 @@ bool send_init(zmq::socket_t &socket, const string client_name)
     if (!socket_recv(socket, zmsgrecv, true))
         return false;
     if (!response.ParseFromArray(zmsgrecv.data(), zmsgrecv.size())) {
-        exchandler.setException("F-UDF.CL.L-4: Failed to parse data");
+        exchandler.setException("F-UDF.CL.LIB-1003: Failed to parse data");
         return false;
     }
 
@@ -374,11 +374,11 @@ bool send_init(zmq::socket_t &socket, const string client_name)
     if (response.type() == MT_CLOSE) {
         if (response.close().has_exception_message())
             exchandler.setException(response.close().exception_message().c_str());
-        else exchandler.setException("F-UDF.CL.L-5: Connection closed by server");
+        else exchandler.setException("F-UDF.CL.LIB-1004: Connection closed by server");
         return false;
     }
     if (response.type() != MT_INFO) {
-        exchandler.setException("F-UDF.CL.L-6: Wrong message type, should be MT_INFO got "+
+        exchandler.setException("F-UDF.CL.LIB-1005: Wrong message type, should be MT_INFO got "+
                                 convert_message_type_to_string(response.type()));
         return false;
     }
@@ -407,42 +407,42 @@ bool send_init(zmq::socket_t &socket, const string client_name)
     d.rlim_cur = d.rlim_max = rep.maximal_memory_limit();
     if (setrlimit(RLIMIT_RSS, &d) != 0)
 #ifdef SWIGVM_LOG_CLIENT
-        cerr << "W-UDF.CL.L-7: Failed to set memory limit" << endl;
+        cerr << "W-UDF.CL.LIB-1006: Failed to set memory limit" << endl;
 #else
-        throw SWIGVM::exception("F-UDF.CL.L-8: Failed to set memory limit");
+        throw SWIGVM::exception("F-UDF.CL.LIB-1007: Failed to set memory limit");
 #endif
     d.rlim_cur = d.rlim_max = 0;    // 0 for no core dumps, RLIM_INFINITY to enable coredumps of any size
     if (setrlimit(RLIMIT_CORE, &d) != 0)
 #ifdef SWIGVM_LOG_CLIENT
-        cerr << "W-UDF.CL.L-9: Failed to set core dump size limit" << endl;
+        cerr << "W-UDF.CL.LIB-1008: Failed to set core dump size limit" << endl;
 #else
-        throw SWIGVM::exception("F-UDF.CL.L-10: Failed to set core dump size limit");
+        throw SWIGVM::exception("F-UDF.CL.LIB-1009: Failed to set core dump size limit");
 #endif
     /* d.rlim_cur = d.rlim_max = 65536; */
     getrlimit(RLIMIT_NOFILE,&d);
     if (d.rlim_max < 32768)
     {
         //#ifdef SWIGVM_LOG_CLIENT
-        cerr << "W-UDF.CL.L-11: Reducing RLIMIT_NOFILE below 32768" << endl;
+        cerr << "W-UDF.CL.LIB-1010: Reducing RLIMIT_NOFILE below 32768" << endl;
         //#endif
     }
     d.rlim_cur = d.rlim_max = std::min(32768,(int)d.rlim_max);
     if (setrlimit(RLIMIT_NOFILE, &d) != 0)
 #ifdef SWIGVM_LOG_CLIENT
-        cerr << "W-UDF.CL.L-12: Failed to set nofile limit" << endl;
+        cerr << "W-UDF.CL.LIB-1011: Failed to set nofile limit" << endl;
 #else
-        throw SWIGVM::exception("F-UDF.CL.L-13: Failed to set nofile limit");
+        throw SWIGVM::exception("F-UDF.CL.LIB-1012: Failed to set nofile limit");
 #endif
     d.rlim_cur = d.rlim_max = 32768;
     if (setrlimit(RLIMIT_NPROC, &d) != 0)
     {
-        cerr << "W-UDF.CL.L-14: Failed to set nproc limit to 32k trying 8k ..." << endl;
+        cerr << "W-UDF.CL.LIB-1013: Failed to set nproc limit to 32k trying 8k ..." << endl;
         d.rlim_cur = d.rlim_max = 8192;
         if (setrlimit(RLIMIT_NPROC, &d) != 0)
 #ifdef SWIGVM_LOG_CLIENT
-            cerr << "W-UDF.CL.L-15: Failed to set nproc limit" << endl;
+            cerr << "W-UDF.CL.LIB-1014: Failed to set nproc limit" << endl;
 #else
-            throw SWIGVM::exception("F-UDF.CL.L-16: Failed to set nproc limit");
+            throw SWIGVM::exception("F-UDF.CL.LIB-1015: Failed to set nproc limit");
 #endif
     }
 
@@ -451,7 +451,7 @@ bool send_init(zmq::socket_t &socket, const string client_name)
         request.set_type(MT_META);
         request.set_connection_id(SWIGVM_params_ref->connection_id);
         if (!request.SerializeToString(&output_buffer)) {
-            exchandler.setException("F-UDF.CL.L-17: Communication error: failed to serialize data");
+            exchandler.setException("F-UDF.CL.LIB-1016: Communication error: failed to serialize data");
             return false;
         }
         zmq::message_t zmsg((void*)output_buffer.c_str(), output_buffer.length(), NULL, NULL);
@@ -461,17 +461,17 @@ bool send_init(zmq::socket_t &socket, const string client_name)
         socket_recv(socket, zmsg);
         response.Clear();
         if (!response.ParseFromArray(zmsg.data(), zmsg.size())) {
-            exchandler.setException("F-UDF.CL.L-18: Communication error: failed to parse data");
+            exchandler.setException("F-UDF.CL.LIB-1017: Communication error: failed to parse data");
             return false;
         }
         if (response.type() == MT_CLOSE) {
             if (response.close().has_exception_message())
                 exchandler.setException(response.close().exception_message().c_str());
-            else exchandler.setException("F-UDF.CL.L-19: Connection closed by server");
+            else exchandler.setException("F-UDF.CL.LIB-1018: Connection closed by server");
             return false;
         }
         if (response.type() != MT_META) {
-            exchandler.setException("F-UDF.CL.L-20: Wrong message type, should be META, got "+
+            exchandler.setException("F-UDF.CL.LIB-1019: Wrong message type, should be META, got "+
                                     convert_message_type_to_string(response.type()));
             return false;
         }
@@ -488,7 +488,7 @@ bool send_init(zmq::socket_t &socket, const string client_name)
             coltype.type_name = coldef.type_name();
             switch (coldef.type()) {
             case PB_UNSUPPORTED:
-                exchandler.setException("F-UDF.CL.L-21: Unsupported input column type found");
+                exchandler.setException("F-UDF.CL.LIB-1020: Unsupported input column type found");
                 return false;
             case PB_DOUBLE:
                 coltype.type = DOUBLE;
@@ -522,7 +522,7 @@ bool send_init(zmq::socket_t &socket, const string client_name)
                 coltype.type = BOOLEAN;
                 break;
             default:
-                exchandler.setException("F-UDF.CL.L-22: Unknown input column type found, got "+coldef.type());
+                exchandler.setException("F-UDF.CL.LIB-1021: Unknown input column type found, got "+coldef.type());
                 return false;
             }
         }
@@ -535,7 +535,7 @@ bool send_init(zmq::socket_t &socket, const string client_name)
             coltype.type_name = coldef.type_name();
             switch (coldef.type()) {
             case PB_UNSUPPORTED:
-                exchandler.setException("F-UDF.CL.L-23: Unsupported output column type found");
+                exchandler.setException("F-UDF.CL.LIB-1022: Unsupported output column type found");
                 return false;
             case PB_DOUBLE:
                 coltype.type = DOUBLE;
@@ -569,7 +569,7 @@ bool send_init(zmq::socket_t &socket, const string client_name)
                 coltype.type = BOOLEAN;
                 break;
             default:
-                exchandler.setException("F-UDF.CL.L-24: Unknown output column type found, got "+coldef.type());
+                exchandler.setException("F-UDF.CL.LIB-1023: Unknown output column type found, got "+coldef.type());
                 return false;
             }
         }
@@ -594,10 +594,10 @@ void send_close(zmq::socket_t &socket, const string &exmsg)
         socket_recv(socket, zmsg);
         response.Clear();
         if(!response.ParseFromArray(zmsg.data(), zmsg.size())){
-            throw SWIGVM::exception("F-UDF.CL.L-25: Communication error: failed to parse data");
+            throw SWIGVM::exception("F-UDF.CL.LIB-1024: Communication error: failed to parse data");
         }
         else if (response.type() != MT_FINISHED){
-            throw SWIGVM::exception("F-UDF.CL.L-26: Wrong response type, should be MT_FINISHED, got "+
+            throw SWIGVM::exception("F-UDF.CL.LIB-1025: Wrong response type, should be MT_FINISHED, got "+
                   convert_message_type_to_string(response.type()));
         }
     }
@@ -612,7 +612,7 @@ bool send_run(zmq::socket_t &socket)
         request.set_connection_id(SWIGVM_params_ref->connection_id);
         if (!request.SerializeToString(&output_buffer))
         {
-            throw SWIGVM::exception("F-UDF.CL.L-27: Communication error: failed to serialize data");
+            throw SWIGVM::exception("F-UDF.CL.LIB-1026: Communication error: failed to serialize data");
         }
         zmq::message_t zmsg((void*)output_buffer.c_str(), output_buffer.length(), NULL, NULL);
         socket_send(socket, zmsg);
@@ -621,11 +621,11 @@ bool send_run(zmq::socket_t &socket)
         socket_recv(socket, zmsg);
         response.Clear();
         if (!response.ParseFromArray(zmsg.data(), zmsg.size()))
-            throw SWIGVM::exception("F-UDF.CL.L-28: Communication error: failed to parse data");
+            throw SWIGVM::exception("F-UDF.CL.LIB-1027: Communication error: failed to parse data");
         if (response.type() == MT_CLOSE) {
             if (response.close().has_exception_message())
                 throw SWIGVM::exception(response.close().exception_message().c_str());
-            throw SWIGVM::exception("F-UDF.CL.L-29: Wrong response type, got empty MT_CLOSE");
+            throw SWIGVM::exception("F-UDF.CL.LIB-1028: Wrong response type, got empty MT_CLOSE");
         } else if (response.type() == MT_CLEANUP) {
             return false;
         } else if (g_singleCallMode && response.type() == MT_CALL) {
@@ -643,7 +643,7 @@ bool send_run(zmq::socket_t &socket)
 
                 if (!sc.has_import_specification())
                 {
-                    throw SWIGVM::exception("F-UDF.CL.L-30: internal error SC_FN_GENERATE_SQL_FOR_IMPORT_SPEC without import specification");
+                    throw SWIGVM::exception("F-UDF.CL.LIB-1029: internal error SC_FN_GENERATE_SQL_FOR_IMPORT_SPEC without import specification");
                 }
                 const import_specification_rep& is_proto = sc.import_specification();
                 g_singleCall_ImportSpecificationArg = ExecutionGraph::ImportSpecification(is_proto.is_subselect());
@@ -676,7 +676,7 @@ bool send_run(zmq::socket_t &socket)
             {
                 if (!sc.has_export_specification())
                 {
-                    throw SWIGVM::exception("F-UDF.CL.L-31: internal error SC_FN_GENERATE_SQL_FOR_EXPORT_SPEC without export specification");
+                    throw SWIGVM::exception("F-UDF.CL.LIB-1030: internal error SC_FN_GENERATE_SQL_FOR_EXPORT_SPEC without export specification");
                 }
                 const export_specification_rep& es_proto = sc.export_specification();
                 g_singleCall_ExportSpecificationArg = ExecutionGraph::ExportSpecification();
@@ -711,7 +711,7 @@ bool send_run(zmq::socket_t &socket)
             case single_call_function_id_e::SC_FN_VIRTUAL_SCHEMA_ADAPTER_CALL:
                 if (!sc.has_json_arg())
                 {
-                    throw SWIGVM::exception("F-UDF.CL.L-32: internal error SC_FN_VIRTUAL_SCHEMA_ADAPTER_CALL without json arg");
+                    throw SWIGVM::exception("F-UDF.CL.LIB-1031: internal error SC_FN_VIRTUAL_SCHEMA_ADAPTER_CALL without json arg");
                 }
                 const std::string json = sc.json_arg();
                 g_singleCall_StringArg = ExecutionGraph::StringDTO(json);
@@ -720,7 +720,7 @@ bool send_run(zmq::socket_t &socket)
 
             return true;
         } else if (response.type() != MT_RUN) {
-            throw SWIGVM::exception("F-UDF.CL.L-33: Wrong response type, should be MT_RUN, got "+
+            throw SWIGVM::exception("F-UDF.CL.LIB-1032: Wrong response type, should be MT_RUN, got "+
                                     convert_message_type_to_string(response.type()));
         }
     }
@@ -738,7 +738,7 @@ bool send_return(zmq::socket_t &socket, const char* result)
         request.set_allocated_call_result(rr);
         request.set_connection_id(SWIGVM_params_ref->connection_id);
         if (!request.SerializeToString(&output_buffer))
-            throw SWIGVM::exception("F-UDF.CL.L-34: Communication error: failed to serialize data");
+            throw SWIGVM::exception("F-UDF.CL.LIB-1033: Communication error: failed to serialize data");
         zmq::message_t zmsg((void*)output_buffer.c_str(), output_buffer.length(), NULL, NULL);
         socket_send(socket, zmsg);
     } { /* receive return response */
@@ -746,15 +746,15 @@ bool send_return(zmq::socket_t &socket, const char* result)
         socket_recv(socket, zmsg);
         response.Clear();
         if (!response.ParseFromArray(zmsg.data(), zmsg.size()))
-            throw SWIGVM::exception("F-UDF.CL.L-35: Communication error: failed to parse data");
+            throw SWIGVM::exception("F-UDF.CL.LIB-1034: Communication error: failed to parse data");
         if (response.type() == MT_CLOSE) {
             if (response.close().has_exception_message())
                 throw SWIGVM::exception(response.close().exception_message().c_str());
-            throw SWIGVM::exception("F-UDF.CL.L-36: Wrong response type, got empty close response");
+            throw SWIGVM::exception("F-UDF.CL.LIB-1035: Wrong response type, got empty close response");
         } else if (response.type() == MT_CLEANUP) {
             return false;
         } else if (response.type() != MT_RETURN) {
-            throw SWIGVM::exception("F-UDF.CL.L-37: Wrong response type, should be MT_RETURN, got "+
+            throw SWIGVM::exception("F-UDF.CL.LIB-1036: Wrong response type, should be MT_RETURN, got "+
                                     convert_message_type_to_string(response.type()));
         }
     }
@@ -771,7 +771,7 @@ void send_undefined_call(zmq::socket_t &socket, const std::string& fn)
         request.set_allocated_undefined_call(uc);
         request.set_connection_id(SWIGVM_params_ref->connection_id);
         if (!request.SerializeToString(&output_buffer))
-            throw SWIGVM::exception("F-UDF.CL.L-38: Communication error: failed to serialize data");
+            throw SWIGVM::exception("F-UDF.CL.LIB-1037: Communication error: failed to serialize data");
         zmq::message_t zmsg((void*)output_buffer.c_str(), output_buffer.length(), NULL, NULL);
         socket_send(socket, zmsg);
     } { /* receive return response */
@@ -779,9 +779,9 @@ void send_undefined_call(zmq::socket_t &socket, const std::string& fn)
         socket_recv(socket, zmsg);
         response.Clear();
         if (!response.ParseFromArray(zmsg.data(), zmsg.size()))
-            throw SWIGVM::exception("F-UDF.CL.L-39: Communication error: failed to parse data");
+            throw SWIGVM::exception("F-UDF.CL.LIB-1038: Communication error: failed to parse data");
         if (response.type() != MT_UNDEFINED_CALL) {
-            throw SWIGVM::exception("F-UDF.CL.L-40: Wrong response type, should be MT_UNDEFINED_CALL, got "+
+            throw SWIGVM::exception("F-UDF.CL.LIB-1039: Wrong response type, should be MT_UNDEFINED_CALL, got "+
                                     convert_message_type_to_string(response.type()));
         }
     }
@@ -795,7 +795,7 @@ bool send_done(zmq::socket_t &socket)
         request.set_type(MT_DONE);
         request.set_connection_id(SWIGVM_params_ref->connection_id);
         if (!request.SerializeToString(&output_buffer))
-            throw SWIGVM::exception("F-UDF.CL.L-41: Communication error: failed to serialize data");
+            throw SWIGVM::exception("F-UDF.CL.LIB-1040: Communication error: failed to serialize data");
         zmq::message_t zmsg((void*)output_buffer.c_str(), output_buffer.length(), NULL, NULL);
         socket_send(socket, zmsg);
     } 
@@ -804,15 +804,15 @@ bool send_done(zmq::socket_t &socket)
         socket_recv(socket, zmsg);
         response.Clear();
         if (!response.ParseFromArray(zmsg.data(), zmsg.size()))
-            throw SWIGVM::exception("F-UDF.CL.L-127: Communication error: failed to parse data");
+            throw SWIGVM::exception("F-UDF.CL.LIB-1041: Communication error: failed to parse data");
         if (response.type() == MT_CLOSE) {
             if (response.close().has_exception_message())
                 throw SWIGVM::exception(response.close().exception_message().c_str());
-            throw SWIGVM::exception("F-UDF.CL.L-42: Wrong response type, got empty close response");
+            throw SWIGVM::exception("F-UDF.CL.LIB-1042: Wrong response type, got empty close response");
         } else if (response.type() == MT_CLEANUP) {
             return false;
         } else if (response.type() != MT_DONE)
-            throw SWIGVM::exception("F-UDF.CL.L-43: Wrong response type, should be MT_DONE, got "+
+            throw SWIGVM::exception("F-UDF.CL.LIB-1043: Wrong response type, should be MT_DONE, got "+
                                     convert_message_type_to_string(response.type()));
     }
     return true;
@@ -825,7 +825,7 @@ void send_finished(zmq::socket_t &socket)
         request.set_type(MT_FINISHED);
         request.set_connection_id(SWIGVM_params_ref->connection_id);
         if (!request.SerializeToString(&output_buffer))
-            throw SWIGVM::exception("F-UDF.CL.L-44: Communication error: failed to serialize data");
+            throw SWIGVM::exception("F-UDF.CL.LIB-1044: Communication error: failed to serialize data");
         zmq::message_t zmsg((void*)output_buffer.c_str(), output_buffer.length(), NULL, NULL);
         socket_send(socket, zmsg);
     } { /* receive done response */
@@ -833,13 +833,13 @@ void send_finished(zmq::socket_t &socket)
         socket_recv(socket, zmsg);
         response.Clear();
         if(!response.ParseFromArray(zmsg.data(), zmsg.size()))
-            throw SWIGVM::exception("F-UDF.CL.L-45: Communication error: failed to parse data");
+            throw SWIGVM::exception("F-UDF.CL.LIB-1045: Communication error: failed to parse data");
         if (response.type() == MT_CLOSE) {
             if (response.close().has_exception_message())
                 throw SWIGVM::exception(response.close().exception_message().c_str());
-            throw SWIGVM::exception("F-UDF.CL.L-46: Wrong response type, got empty MT_CLOSE");
+            throw SWIGVM::exception("F-UDF.CL.LIB-1046: Wrong response type, got empty MT_CLOSE");
         } else if (response.type() != MT_FINISHED)
-            throw SWIGVM::exception("F-UDF.CL.L-47: Wrong response type, should be MT_FINISHED, got"+
+            throw SWIGVM::exception("F-UDF.CL.LIB-1047: Wrong response type, should be MT_FINISHED, got"+
                                     convert_message_type_to_string(response.type()));
     }
 }
@@ -913,7 +913,7 @@ public:
         req->set_script_name(connection_name);
         req->set_kind(PB_IMPORT_CONNECTION_INFORMATION);
         if (!request.SerializeToString(&m_output_buffer)) {
-            m_exch->setException("F-UDF.CL.L-48: Communication error: failed to serialize data");
+            m_exch->setException("F-UDF.CL.LIB-1048: Communication error: failed to serialize data");
             return new ExecutionGraph::ConnectionInformationWrapper(ExecutionGraph::ConnectionInformation());
         }
         zmq::message_t zmsg_req((void*)m_output_buffer.c_str(), m_output_buffer.length(), NULL, NULL);
@@ -922,11 +922,11 @@ public:
         socket_recv(m_socket, zmsg_rep);
         exascript_response response;
         if (!response.ParseFromArray(zmsg_rep.data(), zmsg_rep.size())) {
-            m_exch->setException("F-UDF.CL.L-49: Communication error: failed to parse data");
+            m_exch->setException("F-UDF.CL.LIB-1049: Communication error: failed to parse data");
             return new ExecutionGraph::ConnectionInformationWrapper(ExecutionGraph::ConnectionInformation());
         }
         if (response.type() != MT_IMPORT) {
-            m_exch->setException("F-UDF.CL.L-50: Internal error: wrong message type, got "+
+            m_exch->setException("F-UDF.CL.LIB-1050: Internal error: wrong message type, got "+
                                   convert_message_type_to_string(response.type()));
             return new ExecutionGraph::ConnectionInformationWrapper(ExecutionGraph::ConnectionInformation());
         }
@@ -936,7 +936,7 @@ public:
             return new ExecutionGraph::ConnectionInformationWrapper(ExecutionGraph::ConnectionInformation());
         }
         if (!rep.has_connection_information()) {
-            m_exch->setException("F-UDF.CL.L-51: Internal error: No connection information returned");
+            m_exch->setException("F-UDF.CL.LIB-1051: Internal error: No connection information returned");
             return new ExecutionGraph::ConnectionInformationWrapper(ExecutionGraph::ConnectionInformation());
         }
         connection_information_rep ci = rep.connection_information();
@@ -951,7 +951,7 @@ public:
         req->set_script_name(name);
         req->set_kind(PB_IMPORT_SCRIPT_CODE);
         if (!request.SerializeToString(&m_output_buffer)) {
-            m_exch->setException("F-UDF.CL.L-52: Communication error: failed to serialize data");
+            m_exch->setException("F-UDF.CL.LIB-1052: Communication error: failed to serialize data");
             return NULL;
         }
         zmq::message_t zmsg_req((void*)m_output_buffer.c_str(), m_output_buffer.length(), NULL, NULL);
@@ -960,11 +960,11 @@ public:
         socket_recv(m_socket, zmsg_rep);
         exascript_response response;
         if (!response.ParseFromArray(zmsg_rep.data(), zmsg_rep.size())) {
-            m_exch->setException("F-UDF.CL.L-53: Communication error: failed to parse data");
+            m_exch->setException("F-UDF.CL.LIB-1053: Communication error: failed to parse data");
             return NULL;
         }
         if (response.type() != MT_IMPORT) {
-            m_exch->setException("F-UDF.CL.L-54: Internal error: wrong message type, should MT_IMPORT, got "+
+            m_exch->setException("F-UDF.CL.LIB-1054: Internal error: wrong message type, should MT_IMPORT, got "+
                                   convert_message_type_to_string(response.type()));
             return NULL;
         }
@@ -974,7 +974,7 @@ public:
             return NULL;
         }
         if (!rep.has_source_code()) {
-            m_exch->setException("F-UDF.CL.L-55: Internal error: No source code returned");
+            m_exch->setException("F-UDF.CL.LIB-1055: Internal error: No source code returned");
             return NULL;
         }
         m_temp_code = rep.source_code();
@@ -1122,7 +1122,7 @@ private:
         null_index = m_rows_completed * m_column_count;
         if (m_next_response.next().table().data_nulls_size() <= (null_index + (ssize_t)m_column_count - 1)) {
             std::stringstream sb;
-            sb << "F-UDF.CL.L-56: Internal error: not enough nulls in packet: wanted index " << (null_index + m_column_count - 1)
+            sb << "F-UDF.CL.LIB-1056: Internal error: not enough nulls in packet: wanted index " << (null_index + m_column_count - 1)
                << " but have " << m_next_response.next().table().data_nulls_size()
                << " elements";
             m_exch->setException(sb.str().c_str());
@@ -1134,7 +1134,7 @@ private:
             if (m_next_response.next().table().data_nulls(null_index))
                 continue;
             switch (it->type) {
-              case UNSUPPORTED: m_exch->setException("F-UDF.CL.L-57: Unsupported data type found"); return;
+              case UNSUPPORTED: m_exch->setException("F-UDF.CL.LIB-1057: Unsupported data type found"); return;
               case DOUBLE: m_col_offsets[current_column] = m_values_per_row.doubles++; break;
               case INT32: m_col_offsets[current_column] = m_values_per_row.int32s++; break;
               case INT64: m_col_offsets[current_column] = m_values_per_row.int64s++; break;
@@ -1143,7 +1143,7 @@ private:
               case DATE:
               case STRING: m_col_offsets[current_column] = m_values_per_row.strings++; break;
               case BOOLEAN: m_col_offsets[current_column] = m_values_per_row.bools++; break;
-              default: m_exch->setException("F-UDF.CL.L-58: Unknown data type found, got "+it->type); return;
+              default: m_exch->setException("F-UDF.CL.LIB-1058: Unknown data type found, got "+it->type); return;
             }
         }
     }
@@ -1156,7 +1156,7 @@ private:
             if (reset) m_request.set_type(MT_RESET);
             else m_request.set_type(MT_NEXT);
             if(!m_request.SerializeToString(&m_output_buffer)) {
-                m_exch->setException("F-UDF.CL.L-59: Communication error: failed to serialize data");
+                m_exch->setException("F-UDF.CL.LIB-1059: Communication error: failed to serialize data");
                 return;
             }
             zmq::message_t zmsg((void*)m_output_buffer.c_str(), m_output_buffer.length(), NULL, NULL);
@@ -1166,12 +1166,12 @@ private:
             socket_recv(m_socket, zmsg);
             m_next_response.Clear();
             if (!m_next_response.ParseFromArray(zmsg.data(), zmsg.size())) {
-                m_exch->setException("F-UDF.CL.L-60: Communication error: failed to parse data");
+                m_exch->setException("F-UDF.CL.LIB-1060: Communication error: failed to parse data");
                 return;
             }
             if (m_next_response.connection_id() != m_connection_id) {
                 std::stringstream sb;
-                sb << "F-UDF.CL.L-61: Communication error: wrong connection id, expected "
+                sb << "F-UDF.CL.LIB-1061: Communication error: wrong connection id, expected "
                    << m_connection_id << " got " << m_next_response.connection_id(); 
                 m_exch->setException(sb.str());
                 return;
@@ -1184,7 +1184,7 @@ private:
                 if (!rep.has_exception_message()) {
                     if (m_rows_completed == 0) {
                         return;
-                    } else m_exch->setException("F-UDF.CL.L-62: Unknown error occured");
+                    } else m_exch->setException("F-UDF.CL.LIB-1062: Unknown error occured");
                 } else {
                     m_exch->setException(rep.exception_message().c_str());
                 }
@@ -1193,7 +1193,7 @@ private:
             if ((reset && (m_next_response.type() != MT_RESET)) ||
                     (!reset && (m_next_response.type() != MT_NEXT)))
             {
-                m_exch->setException("F-UDF.CL.L-63: Communication error: wrong message type, got "+
+                m_exch->setException("F-UDF.CL.LIB-1063: Communication error: wrong message type, got "+
                                     convert_message_type_to_string(m_next_response.type()));
                 return;
             }
@@ -1205,7 +1205,7 @@ private:
     inline ssize_t check_index(ssize_t index, ssize_t available, const char *tp, const char *otype, const char *ts) {
         if (available > index) return index;
         std::stringstream sb;
-        sb << "F-UDF.CL.L-64: Internal error: not enough " << tp << otype << ts << " in packet: wanted index "
+        sb << "F-UDF.CL.LIB-1064: Internal error: not enough " << tp << otype << ts << " in packet: wanted index "
            << index << " but have " << available << " elements (on "
            << m_rows_received << '/' << m_rows_completed << " of received/completed rows";
         m_exch->setException(sb.str().c_str());
@@ -1253,7 +1253,7 @@ public:
     }
     inline bool next() {
         if (m_rows_received == 0) {
-            m_exch->setException("E-UDF.CL.L-65: Iteration finished");
+            m_exch->setException("E-UDF.CL.LIB-1065: Iteration finished");
             return false;
         }
         ++m_rows_completed;
@@ -1290,12 +1290,12 @@ public:
     }
     inline double getDouble(unsigned int col) {
         if (col >= m_types.size()) { 
-          m_exch->setException("E-UDF.CL.L-66: Input column "+std::to_string(col)+" does not exist"); 
+          m_exch->setException("E-UDF.CL.LIB-1066: Input column "+std::to_string(col)+" does not exist"); 
           m_was_null = true; 
           return 0.0; 
         }
         if (m_types[col].type != DOUBLE) {
-            m_exch->setException("E-UDF.CL.L-67: Wrong input column type, expected DOUBLE, got "+
+            m_exch->setException("E-UDF.CL.LIB-1067: Wrong input column type, expected DOUBLE, got "+
                                 convert_type_to_string(m_types[col].type));
             m_was_null = true;
             return 0.0;
@@ -1308,12 +1308,12 @@ public:
     }
     inline const char *getString(unsigned int col, size_t *length = NULL) {
         if (col >= m_types.size()) { 
-          m_exch->setException("E-UDF.CL.L-68: Input column "+std::to_string(col)+" does not exist"); 
+          m_exch->setException("E-UDF.CL.LIB-1068: Input column "+std::to_string(col)+" does not exist"); 
           m_was_null = true; 
           return ""; 
         }
         if (m_types[col].type != STRING) {
-            m_exch->setException("E-UDF.CL.L-69: Wrong input column type, expected STRING, got "+
+            m_exch->setException("E-UDF.CL.LIB-1069: Wrong input column type, expected STRING, got "+
                                 convert_type_to_string(m_types[col].type));
             m_was_null = true;
             return "";
@@ -1326,12 +1326,12 @@ public:
     }
     inline int32_t getInt32(unsigned int col) {
         if (col >= m_types.size()) { 
-          m_exch->setException("E-UDF.CL.L-70: Input column "+std::to_string(col)+" does not exist"); 
+          m_exch->setException("E-UDF.CL.LIB-1070: Input column "+std::to_string(col)+" does not exist"); 
           m_was_null = true; 
           return 0; 
         }
         if (m_types[col].type != INT32) {
-            m_exch->setException("E-UDF.CL.L-71: Wrong input column type, expected INT32, got "+
+            m_exch->setException("E-UDF.CL.LIB-1071: Wrong input column type, expected INT32, got "+
                                 convert_type_to_string(m_types[col].type));
             m_was_null = true;
             return 0;
@@ -1342,12 +1342,12 @@ public:
     }
     inline int64_t getInt64(unsigned int col) {
         if (col >= m_types.size()) { 
-          m_exch->setException("E-UDF.CL.L-72: Input column "+std::to_string(col)+" does not exist"); 
+          m_exch->setException("E-UDF.CL.LIB-1072: Input column "+std::to_string(col)+" does not exist"); 
           m_was_null = true; 
           return 0LL; 
         }
         if (m_types[col].type != INT64) {
-            m_exch->setException("E-UDF.CL.L-73: Wrong input column type, expected INT64, got "+
+            m_exch->setException("E-UDF.CL.LIB-1073: Wrong input column type, expected INT64, got "+
                                 convert_type_to_string(m_types[col].type));
             m_was_null = true;
             return 0LL;
@@ -1358,12 +1358,12 @@ public:
     }
     inline const char *getNumeric(unsigned int col) {
         if (col >= m_types.size()) { 
-          m_exch->setException("E-UDF.CL.L-74: Input column "+std::to_string(col)+" does not exist"); 
+          m_exch->setException("E-UDF.CL.LIB-1074: Input column "+std::to_string(col)+" does not exist"); 
           m_was_null = true; 
           return ""; 
         }
         if (m_types[col].type != NUMERIC) { 
-          m_exch->setException("E-UDF.CL.L-75: Wrong input column type, expected NUMERIC, got "+
+          m_exch->setException("E-UDF.CL.LIB-1075: Wrong input column type, expected NUMERIC, got "+
                               convert_type_to_string(m_types[col].type));
           m_was_null = true; 
           return ""; 
@@ -1374,12 +1374,12 @@ public:
     }
     inline const char *getTimestamp(unsigned int col) {
         if (col >= m_types.size()) { 
-          m_exch->setException("E-UDF.CL.L-76: Input column "+std::to_string(col)+" does not exist"); 
+          m_exch->setException("E-UDF.CL.LIB-1076: Input column "+std::to_string(col)+" does not exist"); 
           m_was_null = true; 
           return ""; 
         }
         if (m_types[col].type != TIMESTAMP) { 
-          m_exch->setException("E-UDF.CL.L-77: Wrong input column type, expected TIMESTAMP, got "+
+          m_exch->setException("E-UDF.CL.LIB-1077: Wrong input column type, expected TIMESTAMP, got "+
                               convert_type_to_string(m_types[col].type));
           m_was_null = true; 
           return ""; 
@@ -1390,12 +1390,12 @@ public:
     }
     inline const char *getDate(unsigned int col) {
         if (col >= m_types.size()) { 
-          m_exch->setException("E-UDF.CL.L-78: Input column "+std::to_string(col)+" does not exist"); 
+          m_exch->setException("E-UDF.CL.LIB-1078: Input column "+std::to_string(col)+" does not exist"); 
           m_was_null = true; 
           return ""; 
         }
         if (m_types[col].type != DATE) { 
-          m_exch->setException("E-UDF.CL.L-79: Wrong input column type, expected DATE, got "+
+          m_exch->setException("E-UDF.CL.LIB-1079: Wrong input column type, expected DATE, got "+
                               convert_type_to_string(m_types[col].type));
           m_was_null = true; 
           return ""; 
@@ -1406,12 +1406,12 @@ public:
     }
     inline bool getBoolean(unsigned int col) {
         if (col >= m_types.size()) { 
-          m_exch->setException("E-UDF.CL.L-80: Input column "+std::to_string(col)+" does not exist"); 
+          m_exch->setException("E-UDF.CL.LIB-1080: Input column "+std::to_string(col)+" does not exist"); 
           m_was_null = true; 
           return ""; 
         }
         if (m_types[col].type != BOOLEAN) { 
-          m_exch->setException("E-UDF.CL.L-81: Wrong input column type, expected BOOLEAN, got "+
+          m_exch->setException("E-UDF.CL.LIB-1081: Wrong input column type, expected BOOLEAN, got "+
                               convert_type_to_string(m_types[col].type));
           m_was_null = true; 
           return ""; 
@@ -1470,7 +1470,7 @@ public:
             { m_emit_request.set_type(MT_EMIT);
                 m_emit_request.set_connection_id(m_connection_id);
                 if (!m_emit_request.SerializeToString(&m_output_buffer)) {
-                    m_exch->setException("F-UDF.CL.L-82: Communication error: failed to serialize data");
+                    m_exch->setException("F-UDF.CL.LIB-1082: Communication error: failed to serialize data");
                     return;
                 }
                 zmq::message_t zmsg((void*)m_output_buffer.c_str(), m_output_buffer.length(), NULL, NULL);
@@ -1482,25 +1482,25 @@ public:
                 socket_recv(m_socket, zmsg);
                 exascript_response response;
                 if (!response.ParseFromArray(zmsg.data(), zmsg.size())) {
-                    m_exch->setException("F-UDF.CL.L-83: Communication error: failed to parse data");
+                    m_exch->setException("F-UDF.CL.LIB-1083: Communication error: failed to parse data");
                     return;
                 }
                 if (response.connection_id() != m_connection_id) {
                     std::stringstream sb;
-                    sb << "F-UDF.CL.L-84: Received wrong connection id " << response.connection_id()
+                    sb << "F-UDF.CL.LIB-1084: Received wrong connection id " << response.connection_id()
                        << ", should be " << m_connection_id;
                     m_exch->setException(sb.str().c_str());
                     return;
                 }
                 if (response.type() == MT_CLOSE) {
                     if (!response.close().has_exception_message())
-                        m_exch->setException("F-UDF.CL.L-85: Unknown error occured");
+                        m_exch->setException("F-UDF.CL.LIB-1085: Unknown error occured");
                     else 
                       m_exch->setException(response.close().exception_message().c_str());
                     return;
                 }
                 if (response.type() != MT_EMIT) {
-                    m_exch->setException("F-UDF.CL.L-86: Wrong response type, got "+
+                    m_exch->setException("F-UDF.CL.LIB-1086: Wrong response type, got "+
                                         convert_message_type_to_string(response.type()));
                     return;
                 }
@@ -1517,11 +1517,11 @@ public:
             if (null_data) continue;
             switch (m_types[col].type) {
             case UNSUPPORTED:
-                m_exch->setException("F-UDF.CL.L-87: Unsupported data type found");
+                m_exch->setException("F-UDF.CL.LIB-1087: Unsupported data type found");
                 return false;
             case DOUBLE:
                 if (m_rowdata.double_data.find(col) == m_rowdata.double_data.end()) {
-                    m_exch->setException("F-UDF.CL.L-88: Not enough double columns emited");
+                    m_exch->setException("F-UDF.CL.LIB-1088: Not enough double columns emited");
                     return false;
                 }
                 m_message_size += sizeof(double);
@@ -1529,7 +1529,7 @@ public:
                 break;
             case INT32:
                 if (m_rowdata.int32_data.find(col) == m_rowdata.int32_data.end()) {
-                    m_exch->setException("F-UDF.CL.L-89: Not enough int32 columns emited");
+                    m_exch->setException("F-UDF.CL.LIB-1089: Not enough int32 columns emited");
                     return false;
                 }
                 m_message_size += sizeof(int32_t);
@@ -1537,7 +1537,7 @@ public:
                 break;
             case INT64:
                 if (m_rowdata.int64_data.find(col) == m_rowdata.int64_data.end()) {
-                    m_exch->setException("F-UDF.CL.L-90: Not enough int64 columns emited");
+                    m_exch->setException("F-UDF.CL.LIB-1090: Not enough int64 columns emited");
                     return false;
                 }
                 m_message_size += sizeof(int64_t);
@@ -1548,7 +1548,7 @@ public:
             case DATE:
             case STRING:
                 if (m_rowdata.string_data.find(col) == m_rowdata.string_data.end()) {
-                    m_exch->setException("F-UDF.CL.L-91: Not enough string columns emited");
+                    m_exch->setException("F-UDF.CL.LIB-1091: Not enough string columns emited");
                     return false;
                 }
                 m_message_size += sizeof(int32_t) + m_rowdata.string_data[col].length();
@@ -1556,14 +1556,14 @@ public:
                 break;
             case BOOLEAN:
                 if (m_rowdata.bool_data.find(col) == m_rowdata.bool_data.end()) {
-                    m_exch->setException("F-UDF.CL.L-92: Not enough boolean columns emited");
+                    m_exch->setException("F-UDF.CL.LIB-1092: Not enough boolean columns emited");
                     return false;
                 }
                 m_message_size += 1;
                 table->add_data_bool(m_rowdata.bool_data[col]);
                 break;
             default:
-                m_exch->setException("F-UDF.CL.L-93: Unknown data type found, got "+convert_type_to_string(m_types[col].type));
+                m_exch->setException("F-UDF.CL.LIB-1093: Unknown data type found, got "+convert_type_to_string(m_types[col].type));
                 return false;
             }
         }
@@ -1581,11 +1581,11 @@ public:
     }
     inline void setDouble(unsigned int col, const double v) {
         if (col >= m_types.size()) { 
-          m_exch->setException("E-UDF.CL.L-94: Output column does "+std::to_string(col)+" not exist"); 
+          m_exch->setException("E-UDF.CL.LIB-1094: Output column does "+std::to_string(col)+" not exist"); 
           return; 
         }
         if (m_types[col].type != DOUBLE) { 
-          m_exch->setException("E-UDF.CL.L-95: Wrong output column type, expected DOUBLE, got "+
+          m_exch->setException("E-UDF.CL.LIB-1095: Wrong output column type, expected DOUBLE, got "+
                               convert_type_to_string(m_types[col].type));
           return;
         }
@@ -1594,11 +1594,11 @@ public:
     }
     inline void setString(unsigned int col, const char *v, size_t l) {
         if (col >= m_types.size()) { 
-          m_exch->setException("E-UDF.CL.L-96: Output column does "+std::to_string(col)+" not exist"); 
+          m_exch->setException("E-UDF.CL.LIB-1096: Output column does "+std::to_string(col)+" not exist"); 
           return; 
         }
         if (m_types[col].type != STRING) { 
-          m_exch->setException("E-UDF.CL.L-97: Wrong output column type, expected STRING, got "+
+          m_exch->setException("E-UDF.CL.LIB-1097: Wrong output column type, expected STRING, got "+
                               convert_type_to_string(m_types[col].type));
           return; 
         }
@@ -1607,11 +1607,11 @@ public:
     }
     inline void setInt32(unsigned int col, const int32_t v) {
         if (col >= m_types.size()) { 
-          m_exch->setException("E-UDF.CL.L-98: Output column does "+std::to_string(col)+" not exist"); 
+          m_exch->setException("E-UDF.CL.LIB-1098: Output column does "+std::to_string(col)+" not exist"); 
           return; 
         }
         if (m_types[col].type != INT32) { 
-          m_exch->setException("E-UDF.CL.L-99: Wrong output column type, expected INT32, got "+
+          m_exch->setException("E-UDF.CL.LIB-1099: Wrong output column type, expected INT32, got "+
                               convert_type_to_string(m_types[col].type));
           return; 
         }
@@ -1620,11 +1620,11 @@ public:
     }
     inline void setInt64(unsigned int col, const int64_t v) {
         if (col >= m_types.size()) { 
-          m_exch->setException("E-UDF.CL.L-100: Output column does "+std::to_string(col)+" not exist"); 
+          m_exch->setException("E-UDF.CL.LIB-1100: Output column does "+std::to_string(col)+" not exist"); 
           return; 
         }
         if (m_types[col].type != INT64) { 
-          m_exch->setException("E-UDF.CL.L-101: Wrong output column type, expected INT64, got "+
+          m_exch->setException("E-UDF.CL.LIB-1101: Wrong output column type, expected INT64, got "+
                               convert_type_to_string(m_types[col].type));
           return; 
         }
@@ -1633,11 +1633,11 @@ public:
     }
     inline void setNumeric(unsigned int col, const char *v) {
         if (col >= m_types.size()) { 
-          m_exch->setException("E-UDF.CL.L-102: Output column does "+std::to_string(col)+" not exist"); 
+          m_exch->setException("E-UDF.CL.LIB-1102: Output column does "+std::to_string(col)+" not exist"); 
           return; 
         }
         if (m_types[col].type != NUMERIC) { 
-          m_exch->setException("E-UDF.CL.L-103: Wrong output column type, expected NUMERIC, got "+
+          m_exch->setException("E-UDF.CL.LIB-1103: Wrong output column type, expected NUMERIC, got "+
                               convert_type_to_string(m_types[col].type));
           return; 
         }
@@ -1646,11 +1646,11 @@ public:
     }
     inline void setTimestamp(unsigned int col, const char *v) {
         if (col >= m_types.size()) { 
-          m_exch->setException("E-UDF.CL.L-104: Output column does "+std::to_string(col)+" not exist"); 
+          m_exch->setException("E-UDF.CL.LIB-1104: Output column does "+std::to_string(col)+" not exist"); 
           return; 
         }
         if (m_types[col].type != TIMESTAMP) { 
-          m_exch->setException("E-UDF.CL.L-105: Wrong output column type, expected TIMESTAMP, got "+
+          m_exch->setException("E-UDF.CL.LIB-1105: Wrong output column type, expected TIMESTAMP, got "+
                               convert_type_to_string(m_types[col].type));
           return; 
         }
@@ -1659,11 +1659,11 @@ public:
     }
     inline void setDate(unsigned int col, const char *v) {
         if (col >= m_types.size()) { 
-          m_exch->setException("E-UDF.CL.L-106: Output column does "+std::to_string(col)+" not exist"); 
+          m_exch->setException("E-UDF.CL.LIB-1106: Output column does "+std::to_string(col)+" not exist"); 
           return; 
         }
         if (m_types[col].type != DATE) { 
-          m_exch->setException("E-UDF.CL.L-107: Wrong output column type, expected DATE, got "+
+          m_exch->setException("E-UDF.CL.LIB-1107: Wrong output column type, expected DATE, got "+
                               convert_type_to_string(m_types[col].type));
           return; 
         }
@@ -1672,11 +1672,11 @@ public:
     }
     inline void setBoolean(unsigned int col, const bool v) {
         if (col >= m_types.size()) { 
-          m_exch->setException("E-UDF.CL.L-108: Output column does "+std::to_string(col)+" not exist"); 
+          m_exch->setException("E-UDF.CL.LIB-1108: Output column does "+std::to_string(col)+" not exist"); 
           return; 
         }
         if (m_types[col].type != BOOLEAN) { 
-          m_exch->setException("E-UDF.CL.L-109: Wrong output column type, expected BOOLEAN, got "+
+          m_exch->setException("E-UDF.CL.LIB-1109: Wrong output column type, expected BOOLEAN, got "+
                               convert_type_to_string(m_types[col].type));
           return; 
         }
@@ -1695,37 +1695,37 @@ unsigned int handle_error(zmq::socket_t& socket, std::string socket_name, SWIGVM
             vm->exception_msg = "";
             vm->shutdown(); // Calls cleanup
             if (vm->exception_msg.size()>0) {
-                PRINT_ERROR_MESSAGE(cerr,"F-UDF.CL.L-110","### Caught error in vm->shutdown '" << socket_name << " (" << ::getppid() << ',' << ::getpid() << "): " << vm->exception_msg);
-                msg ="F-UDF.CL.L-111: Caught exception\n\n"+msg+"\n\n and caught another exception during cleanup\n\n"+vm->exception_msg;
+                PRINT_ERROR_MESSAGE(cerr,"F-UDF.CL.LIB-1110","### Caught error in vm->shutdown '" << socket_name << " (" << ::getppid() << ',' << ::getpid() << "): " << vm->exception_msg);
+                msg ="F-UDF.CL.LIB-1111: Caught exception\n\n"+msg+"\n\n and caught another exception during cleanup\n\n"+vm->exception_msg;
             }
         } 
         delete_vm(vm);
     }  catch (SWIGVM::exception &err) {
-        PRINT_ERROR_MESSAGE(cerr,"F-UDF.CL.L-112","### SWIGVM crashing with name '" << socket_name << " (" << ::getppid() << ',' << ::getpid() << "): " << err.what());
+        PRINT_ERROR_MESSAGE(cerr,"F-UDF.CL.LIB-1112","### SWIGVM crashing with name '" << socket_name << " (" << ::getppid() << ',' << ::getpid() << "): " << err.what());
     }catch(std::exception& err){
-        PRINT_ERROR_MESSAGE(cerr,"F-UDF.CL.L-113","### SWIGVM crashing with name '" << socket_name << " (" << ::getppid() << ',' << ::getpid() << "): " << err.what());
+        PRINT_ERROR_MESSAGE(cerr,"F-UDF.CL.LIB-1113","### SWIGVM crashing with name '" << socket_name << " (" << ::getppid() << ',' << ::getpid() << "): " << err.what());
     }catch(...){
-        PRINT_ERROR_MESSAGE(cerr,"F-UDF.CL.L-114","### SWIGVM crashing with name '" << socket_name << " (" << ::getppid() << ',' << ::getpid() << "): ");
+        PRINT_ERROR_MESSAGE(cerr,"F-UDF.CL.LIB-1114","### SWIGVM crashing with name '" << socket_name << " (" << ::getppid() << ',' << ::getpid() << "): ");
     }
     try{
         send_close(socket, msg);
         ::sleep(1); // give me a chance to die with my parent process
     }  catch (SWIGVM::exception &err) {
-        PRINT_ERROR_MESSAGE(cerr,"F-UDF.CL.L-115","### SWIGVM crashing with name '" << socket_name << " (" << ::getppid() << ',' << ::getpid() << "): " << err.what());
+        PRINT_ERROR_MESSAGE(cerr,"F-UDF.CL.LIB-1115","### SWIGVM crashing with name '" << socket_name << " (" << ::getppid() << ',' << ::getpid() << "): " << err.what());
     }catch(std::exception& err){
-        PRINT_ERROR_MESSAGE(cerr,"F-UDF.CL.L-116","### SWIGVM crashing with name '" << socket_name << " (" << ::getppid() << ',' << ::getpid() << "): " << err.what());
+        PRINT_ERROR_MESSAGE(cerr,"F-UDF.CL.LIB-1116","### SWIGVM crashing with name '" << socket_name << " (" << ::getppid() << ',' << ::getpid() << "): " << err.what());
     }catch(...){
-        PRINT_ERROR_MESSAGE(cerr,"F-UDF.CL.L-117","### SWIGVM crashing with name '" << socket_name << " (" << ::getppid() << ',' << ::getpid() << ")");
+        PRINT_ERROR_MESSAGE(cerr,"F-UDF.CL.LIB-1117","### SWIGVM crashing with name '" << socket_name << " (" << ::getppid() << ',' << ::getpid() << ")");
     }
 
     try{
         stop_all(socket);
     }  catch (SWIGVM::exception &err) {
-        PRINT_ERROR_MESSAGE(cerr,"F-UDF.CL.L-118","### SWIGVM crashing with name '" << socket_name << " (" << ::getppid() << ',' << ::getpid() << "): " << err.what());
+        PRINT_ERROR_MESSAGE(cerr,"F-UDF.CL.LIB-1118","### SWIGVM crashing with name '" << socket_name << " (" << ::getppid() << ',' << ::getpid() << "): " << err.what());
     }catch(std::exception& err){
-        PRINT_ERROR_MESSAGE(cerr,"F-UDF.CL.L-119","### SWIGVM crashing with name '" << socket_name << " (" << ::getppid() << ',' << ::getpid() << "): " << err.what());
+        PRINT_ERROR_MESSAGE(cerr,"F-UDF.CL.LIB-1119","### SWIGVM crashing with name '" << socket_name << " (" << ::getppid() << ',' << ::getpid() << "): " << err.what());
     }catch(...){
-        PRINT_ERROR_MESSAGE(cerr,"F-UDF.CL.L-120","### SWIGVM crashing with name '" << socket_name << " (" << ::getppid() << ',' << ::getpid() << "):");
+        PRINT_ERROR_MESSAGE(cerr,"F-UDF.CL.LIB-1120","### SWIGVM crashing with name '" << socket_name << " (" << ::getppid() << ',' << ::getpid() << "):");
     }
     return 1;
 }
@@ -1778,12 +1778,12 @@ int exaudfclient_main(std::function<SWIGVM*()>vmMaker,int argc,char**argv)
                || (strcmp(argv[2], "lang=streaming") == 0)
                || (strcmp(argv[2], "lang=benchmark") == 0)) )
         {
-            PRINT_ERROR_MESSAGE(cerr,"F-UDF.CL.L-121","Remote VM type '" << argv[2] << "' not supported.");
+            PRINT_ERROR_MESSAGE(cerr,"F-UDF.CL.LIB-1121","Remote VM type '" << argv[2] << "' not supported.");
             return 2;
         }
 #endif
     } else {
-        PRINT_ERROR_MESSAGE(cerr,"F-UDF.CL.L-122", "socket name '" << socket_name << "' is invalid." );
+        PRINT_ERROR_MESSAGE(cerr,"F-UDF.CL.LIB-1122", "socket name '" << socket_name << "' is invalid." );
         abort();
     }
 
@@ -1840,7 +1840,7 @@ reinit:
 
     if (!send_init(socket, socket_name)) {
         if (!get_remote_client() && exchandler.exthrowed) {
-            return handle_error(socket, socket_name, vm, "F-UDF.CL.L-128: "+exchandler.exmsg, false);
+            return handle_error(socket, socket_name, vm, "F-UDF.CL.LIB-1123: "+exchandler.exmsg, false);
         }else{
             goto reinit;
         }
@@ -1864,10 +1864,10 @@ reinit:
     try {
         vm = vmMaker();
         if (vm == nullptr) {
-            return handle_error(socket, socket_name, vm, "F-UDF.CL.L-123: Unknown or unsupported VM type", false);
+            return handle_error(socket, socket_name, vm, "F-UDF.CL.LIB-1124: Unknown or unsupported VM type", false);
         }
         if (vm->exception_msg.size()>0) {
-            return handle_error(socket, socket_name, vm, "F-UDF.CL.L-129: "+vm->exception_msg, false);
+            return handle_error(socket, socket_name, vm, "F-UDF.CL.LIB-1125: "+vm->exception_msg, false);
         }
         shutdown_vm_in_case_of_error = true;
         use_zmq_socket_locks = vm->useZmqSocketLocks();
@@ -1907,7 +1907,7 @@ reinit:
                             break;
                     }
                     if (vm->exception_msg.size()>0) {
-                        return handle_error(socket, socket_name, vm, "F-UDF.CL.L-130: "+vm->exception_msg,true);
+                        return handle_error(socket, socket_name, vm, "F-UDF.CL.LIB-1126: "+vm->exception_msg,true);
                     }
 
                     if (vm->calledUndefinedSingleCall.size()>0) {
@@ -1929,7 +1929,7 @@ reinit:
                 while(!vm->run_())
                 {
                     if (vm->exception_msg.size()>0) {
-                        return handle_error(socket, socket_name, vm, "F-UDF.CL.L-131: "+vm->exception_msg,true);
+                        return handle_error(socket, socket_name, vm, "F-UDF.CL.LIB-1127: "+vm->exception_msg,true);
                     }
                 }
                 if (!send_done(socket))
@@ -1941,19 +1941,19 @@ reinit:
         {
             vm->shutdown();
             if (vm->exception_msg.size()>0) {
-                return handle_error(socket, socket_name, vm, "F-UDF.CL.L-132: "+vm->exception_msg,false);
+                return handle_error(socket, socket_name, vm, "F-UDF.CL.LIB-1128: "+vm->exception_msg,false);
             }
         }
         send_finished(socket);
     }  catch (SWIGVM::exception &err) {
         DBG_STREAM_MSG(cerr,"### SWIGVM crashing with name '" << socket_name << " (" << ::getppid() << ',' << ::getpid() << "): " << err.what());
-        return handle_error(socket, socket_name, vm, "F-UDF.CL.L-124: "+std::string(err.what()),shutdown_vm_in_case_of_error);
+        return handle_error(socket, socket_name, vm, "F-UDF.CL.LIB-1129: "+std::string(err.what()),shutdown_vm_in_case_of_error);
     } catch (std::exception &err) {
         DBG_STREAM_MSG(cerr,"### SWIGVM crashing with name '" << socket_name << " (" << ::getppid() << ',' << ::getpid() << "): " << err.what());
-        return handle_error(socket, socket_name, vm, "F-UDF.CL.L-125: "+std::string(err.what()),shutdown_vm_in_case_of_error);
+        return handle_error(socket, socket_name, vm, "F-UDF.CL.LIB-1130: "+std::string(err.what()),shutdown_vm_in_case_of_error);
     } catch (...) {
         DBG_STREAM_MSG(cerr,"### SWIGVM crashing with name '" << socket_name << " (" << ::getppid() << ',' << ::getpid() << ')');
-        return handle_error(socket, socket_name, vm, "F-UDF.CL.L-126: Internal/Unknown error",shutdown_vm_in_case_of_error);
+        return handle_error(socket, socket_name, vm, "F-UDF.CL.LIB-1131: Internal/Unknown error",shutdown_vm_in_case_of_error);
     }
 
     DBG_STREAM_MSG(cerr,"### SWIGVM finishing with name '" << socket_name << " (" << ::getppid() << ',' << ::getpid() << ')');

--- a/exaudfclient/base/javacontainer/BUILD
+++ b/exaudfclient/base/javacontainer/BUILD
@@ -147,7 +147,8 @@ java_library(
             ":ExaExportSpecification.java",
             ":ExaIterationException.java",
             ":ExaIterator.java",
-            ":ExaMetadata.java"
+            ":ExaMetadata.java",
+            ":ExaUDFException.java"
             ],
     resources = ["//:LICENSE-exasol-script-api.txt"],
     deps = [":exaudf"]

--- a/exaudfclient/base/javacontainer/ExaCompiler.java
+++ b/exaudfclient/base/javacontainer/ExaCompiler.java
@@ -22,14 +22,14 @@ class ExaCompiler {
         StringWriter compilationOutput = new StringWriter();
         CompilationTask task = compiler.getTask(compilationOutput, null, null, optionList, null, compilationUnits);
 
-	boolean success = false;
-	try {	
+        boolean success = false;
+        try {	
             success = task.call();
-	} catch (Exception e) {
-		// ignore
-	}
+        } catch (Exception e) {
+            // ignore
+        }
         if (!success) {
-            throw new ExaCompilationException(compilationOutput.toString());
+            throw new ExaCompilationException("F-UDF.CL.J-113: "+compilationOutput.toString());
         }
     }
 

--- a/exaudfclient/base/javacontainer/ExaCompiler.java
+++ b/exaudfclient/base/javacontainer/ExaCompiler.java
@@ -29,7 +29,7 @@ class ExaCompiler {
             // ignore
         }
         if (!success) {
-            throw new ExaCompilationException("F-UDF.CL.J-113: "+compilationOutput.toString());
+            throw new ExaCompilationException("F-UDF.CL.SL.JAVA-1158: "+compilationOutput.toString());
         }
     }
 

--- a/exaudfclient/base/javacontainer/ExaConnectionInformationImpl.java
+++ b/exaudfclient/base/javacontainer/ExaConnectionInformationImpl.java
@@ -13,7 +13,7 @@ public class ExaConnectionInformationImpl implements ExaConnectionInformation {
         if (type.equals("password")) {
             this.type = ConnectionType.PASSWORD;
         } else {
-            throw new IllegalStateException("F-UDF.CL.J-132: ExaConnectionInformationImpl: received unknown connection type: "+type);
+            throw new IllegalStateException("F-UDF.CL.SL.JAVA-1157: ExaConnectionInformationImpl: received unknown connection type: "+type);
         }
         this.address = address;
         this.user = user;

--- a/exaudfclient/base/javacontainer/ExaConnectionInformationImpl.java
+++ b/exaudfclient/base/javacontainer/ExaConnectionInformationImpl.java
@@ -13,7 +13,7 @@ public class ExaConnectionInformationImpl implements ExaConnectionInformation {
         if (type.equals("password")) {
             this.type = ConnectionType.PASSWORD;
         } else {
-            throw new IllegalStateException("ExaConnectionInformationImpl: received unknown connection type: "+type);
+            throw new IllegalStateException("F-UDF.CL.J-132: ExaConnectionInformationImpl: received unknown connection type: "+type);
         }
         this.address = address;
         this.user = user;

--- a/exaudfclient/base/javacontainer/ExaIteratorImpl.java
+++ b/exaudfclient/base/javacontainer/ExaIteratorImpl.java
@@ -30,7 +30,7 @@ class ExaIteratorImpl implements ExaIterator {
         long size = tableIterator.rowsInGroup();
         String exMsg = tableIterator.checkException();
         if (exMsg != null && exMsg.length() > 0) {
-            throw new ExaIterationException(exMsg);
+            throw new ExaIterationException("F-UDF.CL.J-57: "+exMsg);
         }
         return size;
     }
@@ -38,14 +38,14 @@ class ExaIteratorImpl implements ExaIterator {
     @Override
     public boolean next() throws ExaIterationException {
         if (insideRun && singleInput)
-            throw new ExaIterationException("next() function is not allowed in scalar context");
+            throw new ExaIterationException("E-UDF.CL.J-58: next() function is not allowed in scalar context");
         clearCache();
         if (finished)
             return false;
         boolean next = tableIterator.next();
         String exMsg = tableIterator.checkException();
         if (exMsg != null && exMsg.length() > 0) {
-            throw new ExaIterationException(exMsg);
+            throw new ExaIterationException("F-UDF.CL.J-59: "+exMsg);
         }
         if (!next)
             finished = true;
@@ -55,12 +55,12 @@ class ExaIteratorImpl implements ExaIterator {
     @Override
     public void reset() throws ExaIterationException {
         if (singleInput)
-            throw new ExaIterationException("reset() function is not allowed in scalar context");
+            throw new ExaIterationException("E-UDF.CL.J-60: reset() function is not allowed in scalar context");
         clearCache();
         tableIterator.reset();
         String exMsg = tableIterator.checkException();
         if (exMsg != null && exMsg.length() > 0) {
-            throw new ExaIterationException(exMsg);
+            throw new ExaIterationException("F-UDF.CL.J-61: "+exMsg);
         }
         finished = false;
     }
@@ -68,11 +68,11 @@ class ExaIteratorImpl implements ExaIterator {
     @Override
     public void emit(Object... values) throws ExaIterationException, ExaDataTypeException {
         if (insideRun && singleOutput)
-            throw new ExaIterationException("emit() function is not allowed in scalar context");
+            throw new ExaIterationException("E-UDF.CL.J-62: emit() function is not allowed in scalar context");
 
         if(values != null){
             if (values.length != exaMetadata.getOutputColumnCount()) {
-                String errorText = "emit() takes exactly " + exaMetadata.getOutputColumnCount();
+                String errorText = "E-UDF.CL.J-63: emit() takes exactly " + exaMetadata.getOutputColumnCount();
                 errorText += (exaMetadata.getOutputColumnCount() > 1) ? " arguments" : " argument";
                 errorText += " (" + values.length + " given)";
                 throw new ExaIterationException(errorText);
@@ -93,8 +93,14 @@ class ExaIteratorImpl implements ExaIterator {
                     else if (outputColumnTypes[i].equals("DOUBLE"))
                         resultHandler.setDouble(i, val.doubleValue());
                     else
-                        throw new ExaDataTypeException("emit column '" + exaMetadata.getOutputColumnName(i) + "' is of type "
-                                    + outputColumnTypes[i] + " but data given have type " + values[i].getClass().getCanonicalName());
+                        throw new ExaDataTypeException(
+                            "E-UDF.CL.J-64: emit column '" + 
+                            exaMetadata.getOutputColumnName(i) + 
+                            "' is of type " + 
+                            outputColumnTypes[i] + 
+                            " but data given have type " + 
+                            values[i].getClass().getCanonicalName()
+                            );
                 }
                 else if (values[i] instanceof Long) {
                     Long val = (Long) values[i];
@@ -109,8 +115,14 @@ class ExaIteratorImpl implements ExaIterator {
                     else if (outputColumnTypes[i].equals("DOUBLE"))
                         resultHandler.setDouble(i, val.doubleValue());
                     else
-                        throw new ExaDataTypeException("emit column '" + exaMetadata.getOutputColumnName(i) + "' is of type "
-                                    + outputColumnTypes[i] + " but data given have type " + values[i].getClass().getCanonicalName());
+                        throw new ExaDataTypeException(
+                            "E-UDF.CL.J-65: emit column '" + 
+                            exaMetadata.getOutputColumnName(i) + 
+                            "' is of type " + 
+                            outputColumnTypes[i] + 
+                            " but data given have type " + 
+                            values[i].getClass().getCanonicalName()
+                            );
                 }
                 else if (values[i] instanceof Float || values[i] instanceof Double) {
                     Number val = (Number) values[i];
@@ -127,8 +139,14 @@ class ExaIteratorImpl implements ExaIterator {
                     else if (outputColumnTypes[i].equals("DOUBLE"))
                         resultHandler.setDouble(i, val.doubleValue());
                     else
-                        throw new ExaDataTypeException("emit column '" + exaMetadata.getOutputColumnName(i) + "' is of type "
-                                    + outputColumnTypes[i] + " but data given have type " + values[i].getClass().getCanonicalName());
+                        throw new ExaDataTypeException(
+                            "E-UDF.CL.J-66: emit column '" + 
+                            exaMetadata.getOutputColumnName(i) + 
+                            "' is of type "+ 
+                            outputColumnTypes[i] + 
+                            " but data given have type " + 
+                            values[i].getClass().getCanonicalName()
+                            );
                 }
                 else if (values[i] instanceof BigDecimal) {
                     BigDecimal val = (BigDecimal) values[i];
@@ -141,16 +159,28 @@ class ExaIteratorImpl implements ExaIterator {
                     else if (outputColumnTypes[i].equals("DOUBLE"))
                         resultHandler.setDouble(i, val.doubleValue());
                     else
-                        throw new ExaDataTypeException("emit column '" + exaMetadata.getOutputColumnName(i) + "' is of type "
-                                    + outputColumnTypes[i] + " but data given have type " + values[i].getClass().getCanonicalName());
+                        throw new ExaDataTypeException(
+                            "E-UDF.CL.J-67: emit column '" + 
+                            exaMetadata.getOutputColumnName(i) + 
+                            "' is of type " + 
+                            outputColumnTypes[i] + 
+                            " but data given have type " + 
+                            values[i].getClass().getCanonicalName()
+                            );
                 }
                 else if (values[i] instanceof Boolean) {
                     Boolean val = (Boolean) values[i];
                     if (outputColumnTypes[i].equals("BOOLEAN"))
                         resultHandler.setBoolean(i, val.booleanValue());
                     else
-                        throw new ExaDataTypeException("emit column '" + exaMetadata.getOutputColumnName(i) + "' is of type "
-                                    + outputColumnTypes[i] + " but data given have type " + values[i].getClass().getCanonicalName());
+                        throw new ExaDataTypeException(
+                            "E-UDF.CL.J-68: emit column '" + 
+                            exaMetadata.getOutputColumnName(i) + 
+                            "' is of type " + 
+                            outputColumnTypes[i] + 
+                            " but data given have type " + 
+                            values[i].getClass().getCanonicalName()
+                            );
                 }
                 else if (values[i] instanceof String) {
                     String val = (String) values[i];
@@ -159,45 +189,71 @@ class ExaIteratorImpl implements ExaIterator {
                         try {
                             utf8Bytes = val.getBytes("UTF-8");
                         } catch (java.io.UnsupportedEncodingException ex) {
-                            throw new ExaDataTypeException("Column with name '" + exaMetadata.getOutputColumnName(i) + "' contains invalid UTF-8 data");
+                            throw new ExaDataTypeException(
+                                "E-UDF.CL.J-69: Column with name '" + 
+                                exaMetadata.getOutputColumnName(i) + 
+                                "' contains invalid UTF-8 data"
+                                );
                         }
                         resultHandler.setString(i, utf8Bytes);
                     }
                     else
-                        throw new ExaDataTypeException("emit column '" + exaMetadata.getOutputColumnName(i) + "' is of type "
-                                    + outputColumnTypes[i] + " but data given have type " + values[i].getClass().getCanonicalName());
+                        throw new ExaDataTypeException(
+                            "E-UDF.CL.J-70: emit column '" + 
+                            exaMetadata.getOutputColumnName(i) + 
+                            "' is of type " + 
+                            outputColumnTypes[i] + 
+                            " but data given have type " + 
+                            values[i].getClass().getCanonicalName()
+                            );
                 }
                 else if (values[i] instanceof Date) {
                     Date val = (Date) values[i];
                     if (outputColumnTypes[i].equals("DATE"))
                         resultHandler.setDate(i, val.toString());
                     else
-                        throw new ExaDataTypeException("emit column '" + exaMetadata.getOutputColumnName(i) + "' is of type "
-                                    + outputColumnTypes[i] + " but data given have type " + values[i].getClass().getCanonicalName());
+                        throw new ExaDataTypeException(
+                            "E-UDF.CL.J-71: emit column '" + 
+                            exaMetadata.getOutputColumnName(i) + 
+                            "' is of type " + 
+                            outputColumnTypes[i] + 
+                            " but data given have type " + 
+                            values[i].getClass().getCanonicalName()
+                            );
                 }
                 else if (values[i] instanceof Timestamp) {
                     Timestamp val = (Timestamp) values[i];
                     if (outputColumnTypes[i].equals("TIMESTAMP"))
                         resultHandler.setTimestamp(i, val.toString());
                     else
-                        throw new ExaDataTypeException("emit column '" + exaMetadata.getOutputColumnName(i) + "' is of type "
-                                    + outputColumnTypes[i] + " but data given have type " + values[i].getClass().getCanonicalName());
+                        throw new ExaDataTypeException(
+                            "E-UDF.CL.J-72: emit column '" + 
+                            exaMetadata.getOutputColumnName(i) + 
+                            "' is of type " + 
+                            outputColumnTypes[i] + 
+                            " but data given have type " + 
+                            values[i].getClass().getCanonicalName()
+                            );
                 }
                 else {
-                    throw new ExaDataTypeException("emit column '" + exaMetadata.getOutputColumnName(i)
-                                    + "' is of unsupported type " + values[i].getClass().getCanonicalName());
+                    throw new ExaDataTypeException(
+                        "E-UDF.CL.J-73: emit column '" + 
+                        exaMetadata.getOutputColumnName(i) + 
+                        "' is of unsupported type " + 
+                        values[i].getClass().getCanonicalName()
+                        );
                 }
 
                 String exMsg = resultHandler.checkException();
                 if (exMsg != null && exMsg.length() > 0) {
-                    throw new ExaIterationException(exMsg);
+                    throw new ExaIterationException("E-UDF.CL.J-74: "+exMsg);
                 }
             }
         }else{
             if(exaMetadata.getOutputColumnCount()==1){
               resultHandler.setNull(0);
             }else{
-              String errorText = "emit() takes exactly " + exaMetadata.getOutputColumnCount();
+              String errorText = "E-UDF.CL.J-75: emit() takes exactly " + exaMetadata.getOutputColumnCount();
               errorText += (exaMetadata.getOutputColumnCount() > 1) ? " arguments" : " argument";
               errorText += " (" + 1 + " given)";
               throw new ExaIterationException(errorText);
@@ -207,10 +263,10 @@ class ExaIteratorImpl implements ExaIterator {
         boolean next = resultHandler.next();
         String exMsg = resultHandler.checkException();
         if (exMsg != null && exMsg.length() > 0) {
-            throw new ExaIterationException(exMsg);
+            throw new ExaIterationException("F-UDF.CL.J-76: "+exMsg);
         }
         if (!next) {
-            throw new ExaIterationException("Internal error while emiting row");
+            throw new ExaIterationException("F-UDF.CL.J-77: Internal error while emiting row");
         }
     }
 
@@ -230,15 +286,21 @@ class ExaIteratorImpl implements ExaIterator {
         else if (object instanceof Double)
             return new Integer(((Double) object).intValue());
         else
-            throw new ExaDataTypeException("getInteger cannot convert column '" + columnNames.get(column) + "' of type "
-                        + exaMetadata.getInputColumnSqlType(column) + " to an Integer");
+            throw 
+              new ExaDataTypeException(
+                "E-UDF.CL.J-78: getInteger cannot convert column '" + 
+                columnNames.get(column) + 
+                "' of type " + 
+                exaMetadata.getInputColumnSqlType(column) + 
+                " to an Integer"
+                );
     }
 
     @Override
     public Integer getInteger(String name) throws ExaIterationException, ExaDataTypeException {
         int col = columnNames.indexOf(name);
         if (col == -1)
-            throw new ExaIterationException("Column with name '" + name + "' does not exist");
+            throw new ExaIterationException("E-UDF.CL.J-79: Column with name '" + name + "' does not exist");
         return getInteger(col);
     }
 
@@ -258,15 +320,21 @@ class ExaIteratorImpl implements ExaIterator {
         else if (object instanceof Double)
             return new Long(((Double) object).longValue());
         else
-            throw new ExaDataTypeException("getLong cannot convert column '" + columnNames.get(column) + "' of type "
-                        + exaMetadata.getInputColumnSqlType(column) + " to a Long");
+            throw 
+              new ExaDataTypeException(
+                "E-UDF.CL.J-80: getLong cannot convert column '" + 
+                columnNames.get(column) + 
+                "' of type " + 
+                exaMetadata.getInputColumnSqlType(column) + 
+                " to a Long"
+                );
     }
 
     @Override
     public Long getLong(String name) throws ExaIterationException, ExaDataTypeException {
         int col = columnNames.indexOf(name);
         if (col == -1)
-            throw new ExaIterationException("Column with name '" + name + "' does not exist");
+            throw new ExaIterationException("E-UDF.CL.J-81: Column with name '" + name + "' does not exist");
         return getLong(col);
     }
 
@@ -284,15 +352,21 @@ class ExaIteratorImpl implements ExaIterator {
         else if (object instanceof Double)
             return new BigDecimal(((Double) object).doubleValue());
         else
-            throw new ExaDataTypeException("getBigDecimal cannot convert column '" + columnNames.get(column) + "' of type "
-                        + exaMetadata.getInputColumnSqlType(column) + " to a BigDecimal");
+            throw 
+              new ExaDataTypeException(
+                "E-UDF.CL.J-82: getBigDecimal cannot convert column '" + 
+                columnNames.get(column) + 
+                "' of type " + 
+                exaMetadata.getInputColumnSqlType(column) + 
+                " to a BigDecimal"
+                );
     }
 
     @Override
     public BigDecimal getBigDecimal(String name) throws ExaIterationException, ExaDataTypeException {
         int col = columnNames.indexOf(name);
         if (col == -1)
-            throw new ExaIterationException("Column with name '" + name + "' does not exist");
+            throw new ExaIterationException("E-UDF.CL.J-83: Column with name '" + name + "' does not exist");
         return getBigDecimal(col);
     }
 
@@ -310,15 +384,21 @@ class ExaIteratorImpl implements ExaIterator {
         else if (object instanceof Double)
             return (Double) object;
         else
-            throw new ExaDataTypeException("getDouble cannot convert column '" + columnNames.get(column) + "' of type "
-                        + exaMetadata.getInputColumnSqlType(column) + " to a Double");
+            throw 
+              new ExaDataTypeException(
+                  "E-UDF.CL.J-84: getDouble cannot convert column '" + 
+                  columnNames.get(column) + 
+                  "' of type " + 
+                  exaMetadata.getInputColumnSqlType(column) + 
+                  " to a Double"
+                  );
     }
 
     @Override
     public Double getDouble(String name) throws ExaIterationException, ExaDataTypeException {
         int col = columnNames.indexOf(name);
         if (col == -1)
-            throw new ExaIterationException("Column with name '" + name + "' does not exist");
+            throw new ExaIterationException("E-UDF.CL.J-85: Column with name '" + name + "' does not exist");
         return getDouble(col);
     }
 
@@ -333,15 +413,21 @@ class ExaIteratorImpl implements ExaIterator {
                     object instanceof Boolean || object instanceof Date || object instanceof Timestamp)
             return object.toString();
         else
-            throw new ExaDataTypeException("getString cannot convert column '" + columnNames.get(column) + "' of type "
-                        + exaMetadata.getInputColumnSqlType(column) + " to a String");
+            throw 
+              new ExaDataTypeException(
+                  "E-UDF.CL.J-86: getString cannot convert column '" + 
+                  columnNames.get(column) + 
+                  "' of type " + 
+                  exaMetadata.getInputColumnSqlType(column) + 
+                  " to a String"
+                  );
     }
 
     @Override
     public String getString(String name) throws ExaIterationException, ExaDataTypeException {
         int col = columnNames.indexOf(name);
         if (col == -1)
-            throw new ExaIterationException("Column with name '" + name + "' does not exist");
+            throw new ExaIterationException("E-UDF.CL.J-87: Column with name '" + name + "' does not exist");
         return getString(col);
     }
 
@@ -353,15 +439,20 @@ class ExaIteratorImpl implements ExaIterator {
         if (object instanceof Boolean)
             return (Boolean) object;
         else
-            throw new ExaDataTypeException("getBoolean cannot convert column '" + columnNames.get(column) + "' of type "
-                        + exaMetadata.getInputColumnSqlType(column) + " to a Boolean");
+            throw new ExaDataTypeException(
+                "E-UDF.CL.J-88: getBoolean cannot convert column '" + 
+                columnNames.get(column) + 
+                "' of type " + 
+                exaMetadata.getInputColumnSqlType(column) + 
+                " to a Boolean"
+                );
     }
 
     @Override
     public Boolean getBoolean(String name) throws ExaIterationException, ExaDataTypeException {
         int col = columnNames.indexOf(name);
         if (col == -1)
-            throw new ExaIterationException("Column with name '" + name + "' does not exist");
+            throw new ExaIterationException("E-UDF.CL.J-89: Column with name '" + name + "' does not exist");
         return getBoolean(col);
     }
 
@@ -373,15 +464,20 @@ class ExaIteratorImpl implements ExaIterator {
         if (object instanceof Date)
             return (Date) object;
         else
-            throw new ExaDataTypeException("getDate cannot convert column '" + columnNames.get(column) + "' of type "
-                        + exaMetadata.getInputColumnSqlType(column) + " to a Date");
+            throw 
+              new ExaDataTypeException(
+                  "E-UDF.CL.J-90: getDate cannot convert column '" + 
+                  columnNames.get(column) + 
+                  "' of type " + 
+                  exaMetadata.getInputColumnSqlType(column) + 
+                  " to a Date");
     }
 
     @Override
     public Date getDate(String name) throws ExaIterationException, ExaDataTypeException {
         int col = columnNames.indexOf(name);
         if (col == -1)
-            throw new ExaIterationException("Column with name '" + name + "' does not exist");
+            throw new ExaIterationException("E-UDF.CL.J-91: Column with name '" + name + "' does not exist");
         return getDate(col);
     }
 
@@ -393,25 +489,31 @@ class ExaIteratorImpl implements ExaIterator {
         if (object instanceof Timestamp)
             return (Timestamp) object;
         else
-            throw new ExaDataTypeException("getTimestamp cannot convert column '" + columnNames.get(column) + "' of type "
-                        + exaMetadata.getInputColumnSqlType(column) + " to a Timestamp");
+            throw 
+              new ExaDataTypeException(
+                  "E-UDF.CL.J-92: getTimestamp cannot convert column '" + 
+                  columnNames.get(column) + 
+                  "' of type " + 
+                  exaMetadata.getInputColumnSqlType(column) + 
+                  " to a Timestamp"
+                  );
     }
 
     @Override
     public Timestamp getTimestamp(String name) throws ExaIterationException, ExaDataTypeException {
         int col = columnNames.indexOf(name);
         if (col == -1)
-            throw new ExaIterationException("Column with name '" + name + "' does not exist");
+            throw new ExaIterationException("E-UDF.CL.J-93: Column with name '" + name + "' does not exist");
         return getTimestamp(col);
     }
 
     @Override
     public Object getObject(int column) throws ExaIterationException, ExaDataTypeException {
         if (column < 0 || column >= exaMetadata.getInputColumnCount())
-            throw new ExaIterationException("Column number " + column + " does not exist");
+            throw new ExaIterationException("E-UDF.CL.J-94: Column number " + column + " does not exist");
 
         if (finished)
-            throw new ExaIterationException("Iteration finished");
+            throw new ExaIterationException("E-UDF.CL.J-95: Iteration finished");
 
         if (cache[column] != null)
             return cache[column];
@@ -437,7 +539,7 @@ class ExaIteratorImpl implements ExaIterator {
                 try {
                     val = new String(utf8Bytes, "UTF-8");
                 } catch (java.io.UnsupportedEncodingException ex) {
-                    throw new ExaDataTypeException("Column with name '" + columnNames.get(column) + "' contains invalid UTF-8 data");
+                    throw new ExaDataTypeException("F-UDF.CL.J-96: Column with name '" + columnNames.get(column) + "' contains invalid UTF-8 data");
                 }
                 break;
             case "BOOLEAN":
@@ -454,7 +556,7 @@ class ExaIteratorImpl implements ExaIterator {
                     val = Timestamp.valueOf(timestamp);
                 break;
             default:
-                throw new ExaDataTypeException("Column with name '" + columnNames.get(column) + "' has an invalid data type");
+                throw new ExaDataTypeException("F-UDF.CL.J-97: Column with name '" + columnNames.get(column) + "' has an invalid data type");
         }
         if (tableIterator.wasNull())
             val = null;
@@ -466,7 +568,7 @@ class ExaIteratorImpl implements ExaIterator {
     public Object getObject(String name) throws ExaIterationException, ExaDataTypeException {
         int col = columnNames.indexOf(name);
         if (col == -1)
-            throw new ExaIterationException("Column with name '" + name + "' does not exist");
+            throw new ExaIterationException("E-UDF.CL.J-98: Column with name '" + name + "' does not exist");
         return getObject(col);
     }
 
@@ -477,33 +579,33 @@ class ExaIteratorImpl implements ExaIterator {
         if (from instanceof Long) {
             long val = (Long) from;
             if (val > Integer.MAX_VALUE)
-                throw new ExaDataTypeException("emit column '" + name + "' has value of "
+                throw new ExaDataTypeException("E-UDF.CL.J-99: emit column '" + name + "' has value of "
                             + val + " but column can only have maximum value of " + Integer.MAX_VALUE);
             if (val < Integer.MIN_VALUE)
-                throw new ExaDataTypeException("emit column '" + name + "' has value of "
+                throw new ExaDataTypeException("E-UDF.CL.J-100: emit column '" + name + "' has value of "
                             + val + " but column can only have minimum value of " + Integer.MIN_VALUE);
         }
         else if (from instanceof Float) {
             float val = (Float) from;
             if (val > Integer.MAX_VALUE)
-                throw new ExaDataTypeException("emit column '" + name + "' has value of "
+                throw new ExaDataTypeException("E-UDF.CL.J-101: emit column '" + name + "' has value of "
                             + val + " but column can only have maximum value of " + Integer.MAX_VALUE);
             if (val < Integer.MIN_VALUE)
-                throw new ExaDataTypeException("emit column '" + name + "' has value of "
+                throw new ExaDataTypeException("E-UDF.CL.J-102: emit column '" + name + "' has value of "
                             + val + " but column can only have minimum value of " + Integer.MIN_VALUE);
             if (val != Math.floor(val))
-                throw new ExaDataTypeException("emit column '" + name + "' has a non-integer value of " + val);
+                throw new ExaDataTypeException("E-UDF.CL.J-103: emit column '" + name + "' has a non-integer value of " + val);
         }
         else if (from instanceof Double) {
             double val = (Double) from;
             if (val > Integer.MAX_VALUE)
-                throw new ExaDataTypeException("emit column '" + name + "' has value of "
+                throw new ExaDataTypeException("E-UDF.CL.J-112: emit column '" + name + "' has value of "
                             + val + " but column can only have maximum value of " + Integer.MAX_VALUE);
             if (val < Integer.MIN_VALUE)
-                throw new ExaDataTypeException("emit column '" + name + "' has value of "
+                throw new ExaDataTypeException("E-UDF.CL.J-104: emit column '" + name + "' has value of "
                             + val + " but column can only have minimum value of " + Integer.MIN_VALUE);
             if (val != Math.floor(val))
-                throw new ExaDataTypeException("emit column '" + name + "' has a non-integer value of " + val);
+                throw new ExaDataTypeException("E-UDF.CL.J-105: emit column '" + name + "' has a non-integer value of " + val);
         }
 
         return true;
@@ -516,24 +618,24 @@ class ExaIteratorImpl implements ExaIterator {
         if (from instanceof Float) {
             float val = (Float) from;
             if (val > Long.MAX_VALUE)
-                throw new ExaDataTypeException("emit column '" + name + "' has value of "
+                throw new ExaDataTypeException("E-UDF.CL.J-106: emit column '" + name + "' has value of "
                             + val + " but column can only have maximum value of " + Long.MAX_VALUE);
             if (val < Long.MIN_VALUE)
-                throw new ExaDataTypeException("emit column '" + name + "' has value of "
+                throw new ExaDataTypeException("E-UDF.CL.J-107: emit column '" + name + "' has value of "
                             + val + " but column can only have minimum value of " + Long.MIN_VALUE);
             if (val != Math.floor(val))
-                throw new ExaDataTypeException("emit column '" + name + "' has a non-integer value of " + val);
+                throw new ExaDataTypeException("E-UDF.CL.J-108: emit column '" + name + "' has a non-integer value of " + val);
         }
         else if (from instanceof Double) {
             double val = (Double) from;
             if (val > Long.MAX_VALUE)
-                throw new ExaDataTypeException("emit column '" + name + "' has value of "
+                throw new ExaDataTypeException("E-UDF.CL.J-109: emit column '" + name + "' has value of "
                             + val + " but column can only have maximum value of " + Long.MAX_VALUE);
             if (val < Long.MIN_VALUE)
-                throw new ExaDataTypeException("emit column '" + name + "' has value of "
+                throw new ExaDataTypeException("E-UDF.CL.J-110: emit column '" + name + "' has value of "
                             + val + " but column can only have minimum value of " + Long.MIN_VALUE);
             if (val != Math.floor(val))
-                throw new ExaDataTypeException("emit column '" + name + "' has a non-integer value of " + val);
+                throw new ExaDataTypeException("E-UDF.CL.J-111: emit column '" + name + "' has a non-integer value of " + val);
         }
 
         return true;

--- a/exaudfclient/base/javacontainer/ExaIteratorImpl.java
+++ b/exaudfclient/base/javacontainer/ExaIteratorImpl.java
@@ -30,7 +30,7 @@ class ExaIteratorImpl implements ExaIterator {
         long size = tableIterator.rowsInGroup();
         String exMsg = tableIterator.checkException();
         if (exMsg != null && exMsg.length() > 0) {
-            throw new ExaIterationException("F-UDF.CL.J-57: "+exMsg);
+            throw new ExaIterationException("F-UDF.CL.SL.JAVA-1101: "+exMsg);
         }
         return size;
     }
@@ -38,14 +38,14 @@ class ExaIteratorImpl implements ExaIterator {
     @Override
     public boolean next() throws ExaIterationException {
         if (insideRun && singleInput)
-            throw new ExaIterationException("E-UDF.CL.J-58: next() function is not allowed in scalar context");
+            throw new ExaIterationException("E-UDF.CL.SL.JAVA-1102: next() function is not allowed in scalar context");
         clearCache();
         if (finished)
             return false;
         boolean next = tableIterator.next();
         String exMsg = tableIterator.checkException();
         if (exMsg != null && exMsg.length() > 0) {
-            throw new ExaIterationException("F-UDF.CL.J-59: "+exMsg);
+            throw new ExaIterationException("F-UDF.CL.SL.JAVA-1103: "+exMsg);
         }
         if (!next)
             finished = true;
@@ -55,12 +55,12 @@ class ExaIteratorImpl implements ExaIterator {
     @Override
     public void reset() throws ExaIterationException {
         if (singleInput)
-            throw new ExaIterationException("E-UDF.CL.J-60: reset() function is not allowed in scalar context");
+            throw new ExaIterationException("E-UDF.CL.SL.JAVA-1104: reset() function is not allowed in scalar context");
         clearCache();
         tableIterator.reset();
         String exMsg = tableIterator.checkException();
         if (exMsg != null && exMsg.length() > 0) {
-            throw new ExaIterationException("F-UDF.CL.J-61: "+exMsg);
+            throw new ExaIterationException("F-UDF.CL.SL.JAVA-1105: "+exMsg);
         }
         finished = false;
     }
@@ -68,11 +68,11 @@ class ExaIteratorImpl implements ExaIterator {
     @Override
     public void emit(Object... values) throws ExaIterationException, ExaDataTypeException {
         if (insideRun && singleOutput)
-            throw new ExaIterationException("E-UDF.CL.J-62: emit() function is not allowed in scalar context");
+            throw new ExaIterationException("E-UDF.CL.SL.JAVA-1106: emit() function is not allowed in scalar context");
 
         if(values != null){
             if (values.length != exaMetadata.getOutputColumnCount()) {
-                String errorText = "E-UDF.CL.J-63: emit() takes exactly " + exaMetadata.getOutputColumnCount();
+                String errorText = "E-UDF.CL.SL.JAVA-1107: emit() takes exactly " + exaMetadata.getOutputColumnCount();
                 errorText += (exaMetadata.getOutputColumnCount() > 1) ? " arguments" : " argument";
                 errorText += " (" + values.length + " given)";
                 throw new ExaIterationException(errorText);
@@ -94,7 +94,7 @@ class ExaIteratorImpl implements ExaIterator {
                         resultHandler.setDouble(i, val.doubleValue());
                     else
                         throw new ExaDataTypeException(
-                            "E-UDF.CL.J-64: emit column '" + 
+                            "E-UDF.CL.SL.JAVA-1108: emit column '" + 
                             exaMetadata.getOutputColumnName(i) + 
                             "' is of type " + 
                             outputColumnTypes[i] + 
@@ -116,7 +116,7 @@ class ExaIteratorImpl implements ExaIterator {
                         resultHandler.setDouble(i, val.doubleValue());
                     else
                         throw new ExaDataTypeException(
-                            "E-UDF.CL.J-65: emit column '" + 
+                            "E-UDF.CL.SL.JAVA-1109: emit column '" + 
                             exaMetadata.getOutputColumnName(i) + 
                             "' is of type " + 
                             outputColumnTypes[i] + 
@@ -140,7 +140,7 @@ class ExaIteratorImpl implements ExaIterator {
                         resultHandler.setDouble(i, val.doubleValue());
                     else
                         throw new ExaDataTypeException(
-                            "E-UDF.CL.J-66: emit column '" + 
+                            "E-UDF.CL.SL.JAVA-1110: emit column '" + 
                             exaMetadata.getOutputColumnName(i) + 
                             "' is of type "+ 
                             outputColumnTypes[i] + 
@@ -160,7 +160,7 @@ class ExaIteratorImpl implements ExaIterator {
                         resultHandler.setDouble(i, val.doubleValue());
                     else
                         throw new ExaDataTypeException(
-                            "E-UDF.CL.J-67: emit column '" + 
+                            "E-UDF.CL.SL.JAVA-1111: emit column '" + 
                             exaMetadata.getOutputColumnName(i) + 
                             "' is of type " + 
                             outputColumnTypes[i] + 
@@ -174,7 +174,7 @@ class ExaIteratorImpl implements ExaIterator {
                         resultHandler.setBoolean(i, val.booleanValue());
                     else
                         throw new ExaDataTypeException(
-                            "E-UDF.CL.J-68: emit column '" + 
+                            "E-UDF.CL.SL.JAVA-1112: emit column '" + 
                             exaMetadata.getOutputColumnName(i) + 
                             "' is of type " + 
                             outputColumnTypes[i] + 
@@ -190,7 +190,7 @@ class ExaIteratorImpl implements ExaIterator {
                             utf8Bytes = val.getBytes("UTF-8");
                         } catch (java.io.UnsupportedEncodingException ex) {
                             throw new ExaDataTypeException(
-                                "E-UDF.CL.J-69: Column with name '" + 
+                                "E-UDF.CL.SL.JAVA-1113: Column with name '" + 
                                 exaMetadata.getOutputColumnName(i) + 
                                 "' contains invalid UTF-8 data"
                                 );
@@ -199,7 +199,7 @@ class ExaIteratorImpl implements ExaIterator {
                     }
                     else
                         throw new ExaDataTypeException(
-                            "E-UDF.CL.J-70: emit column '" + 
+                            "E-UDF.CL.SL.JAVA-1114: emit column '" + 
                             exaMetadata.getOutputColumnName(i) + 
                             "' is of type " + 
                             outputColumnTypes[i] + 
@@ -213,7 +213,7 @@ class ExaIteratorImpl implements ExaIterator {
                         resultHandler.setDate(i, val.toString());
                     else
                         throw new ExaDataTypeException(
-                            "E-UDF.CL.J-71: emit column '" + 
+                            "E-UDF.CL.SL.JAVA-1115: emit column '" + 
                             exaMetadata.getOutputColumnName(i) + 
                             "' is of type " + 
                             outputColumnTypes[i] + 
@@ -227,7 +227,7 @@ class ExaIteratorImpl implements ExaIterator {
                         resultHandler.setTimestamp(i, val.toString());
                     else
                         throw new ExaDataTypeException(
-                            "E-UDF.CL.J-72: emit column '" + 
+                            "E-UDF.CL.SL.JAVA-1116: emit column '" + 
                             exaMetadata.getOutputColumnName(i) + 
                             "' is of type " + 
                             outputColumnTypes[i] + 
@@ -237,7 +237,7 @@ class ExaIteratorImpl implements ExaIterator {
                 }
                 else {
                     throw new ExaDataTypeException(
-                        "E-UDF.CL.J-73: emit column '" + 
+                        "E-UDF.CL.SL.JAVA-1117: emit column '" + 
                         exaMetadata.getOutputColumnName(i) + 
                         "' is of unsupported type " + 
                         values[i].getClass().getCanonicalName()
@@ -246,14 +246,14 @@ class ExaIteratorImpl implements ExaIterator {
 
                 String exMsg = resultHandler.checkException();
                 if (exMsg != null && exMsg.length() > 0) {
-                    throw new ExaIterationException("E-UDF.CL.J-74: "+exMsg);
+                    throw new ExaIterationException("E-UDF.CL.SL.JAVA-1118: "+exMsg);
                 }
             }
         }else{
             if(exaMetadata.getOutputColumnCount()==1){
               resultHandler.setNull(0);
             }else{
-              String errorText = "E-UDF.CL.J-75: emit() takes exactly " + exaMetadata.getOutputColumnCount();
+              String errorText = "E-UDF.CL.SL.JAVA-1119: emit() takes exactly " + exaMetadata.getOutputColumnCount();
               errorText += (exaMetadata.getOutputColumnCount() > 1) ? " arguments" : " argument";
               errorText += " (" + 1 + " given)";
               throw new ExaIterationException(errorText);
@@ -263,10 +263,10 @@ class ExaIteratorImpl implements ExaIterator {
         boolean next = resultHandler.next();
         String exMsg = resultHandler.checkException();
         if (exMsg != null && exMsg.length() > 0) {
-            throw new ExaIterationException("F-UDF.CL.J-76: "+exMsg);
+            throw new ExaIterationException("F-UDF.CL.SL.JAVA-1120: "+exMsg);
         }
         if (!next) {
-            throw new ExaIterationException("F-UDF.CL.J-77: Internal error while emiting row");
+            throw new ExaIterationException("F-UDF.CL.SL.JAVA-1121: Internal error while emiting row");
         }
     }
 
@@ -288,7 +288,7 @@ class ExaIteratorImpl implements ExaIterator {
         else
             throw 
               new ExaDataTypeException(
-                "E-UDF.CL.J-78: getInteger cannot convert column '" + 
+                "E-UDF.CL.SL.JAVA-1122: getInteger cannot convert column '" + 
                 columnNames.get(column) + 
                 "' of type " + 
                 exaMetadata.getInputColumnSqlType(column) + 
@@ -300,7 +300,7 @@ class ExaIteratorImpl implements ExaIterator {
     public Integer getInteger(String name) throws ExaIterationException, ExaDataTypeException {
         int col = columnNames.indexOf(name);
         if (col == -1)
-            throw new ExaIterationException("E-UDF.CL.J-79: Column with name '" + name + "' does not exist");
+            throw new ExaIterationException("E-UDF.CL.SL.JAVA-1123: Column with name '" + name + "' does not exist");
         return getInteger(col);
     }
 
@@ -322,7 +322,7 @@ class ExaIteratorImpl implements ExaIterator {
         else
             throw 
               new ExaDataTypeException(
-                "E-UDF.CL.J-80: getLong cannot convert column '" + 
+                "E-UDF.CL.SL.JAVA-1124: getLong cannot convert column '" + 
                 columnNames.get(column) + 
                 "' of type " + 
                 exaMetadata.getInputColumnSqlType(column) + 
@@ -334,7 +334,7 @@ class ExaIteratorImpl implements ExaIterator {
     public Long getLong(String name) throws ExaIterationException, ExaDataTypeException {
         int col = columnNames.indexOf(name);
         if (col == -1)
-            throw new ExaIterationException("E-UDF.CL.J-81: Column with name '" + name + "' does not exist");
+            throw new ExaIterationException("E-UDF.CL.SL.JAVA-1125: Column with name '" + name + "' does not exist");
         return getLong(col);
     }
 
@@ -354,7 +354,7 @@ class ExaIteratorImpl implements ExaIterator {
         else
             throw 
               new ExaDataTypeException(
-                "E-UDF.CL.J-82: getBigDecimal cannot convert column '" + 
+                "E-UDF.CL.SL.JAVA-1126: getBigDecimal cannot convert column '" + 
                 columnNames.get(column) + 
                 "' of type " + 
                 exaMetadata.getInputColumnSqlType(column) + 
@@ -366,7 +366,7 @@ class ExaIteratorImpl implements ExaIterator {
     public BigDecimal getBigDecimal(String name) throws ExaIterationException, ExaDataTypeException {
         int col = columnNames.indexOf(name);
         if (col == -1)
-            throw new ExaIterationException("E-UDF.CL.J-83: Column with name '" + name + "' does not exist");
+            throw new ExaIterationException("E-UDF.CL.SL.JAVA-1127: Column with name '" + name + "' does not exist");
         return getBigDecimal(col);
     }
 
@@ -386,7 +386,7 @@ class ExaIteratorImpl implements ExaIterator {
         else
             throw 
               new ExaDataTypeException(
-                  "E-UDF.CL.J-84: getDouble cannot convert column '" + 
+                  "E-UDF.CL.SL.JAVA-1128: getDouble cannot convert column '" + 
                   columnNames.get(column) + 
                   "' of type " + 
                   exaMetadata.getInputColumnSqlType(column) + 
@@ -398,7 +398,7 @@ class ExaIteratorImpl implements ExaIterator {
     public Double getDouble(String name) throws ExaIterationException, ExaDataTypeException {
         int col = columnNames.indexOf(name);
         if (col == -1)
-            throw new ExaIterationException("E-UDF.CL.J-85: Column with name '" + name + "' does not exist");
+            throw new ExaIterationException("E-UDF.CL.SL.JAVA-1129: Column with name '" + name + "' does not exist");
         return getDouble(col);
     }
 
@@ -415,7 +415,7 @@ class ExaIteratorImpl implements ExaIterator {
         else
             throw 
               new ExaDataTypeException(
-                  "E-UDF.CL.J-86: getString cannot convert column '" + 
+                  "E-UDF.CL.SL.JAVA-1130: getString cannot convert column '" + 
                   columnNames.get(column) + 
                   "' of type " + 
                   exaMetadata.getInputColumnSqlType(column) + 
@@ -427,7 +427,7 @@ class ExaIteratorImpl implements ExaIterator {
     public String getString(String name) throws ExaIterationException, ExaDataTypeException {
         int col = columnNames.indexOf(name);
         if (col == -1)
-            throw new ExaIterationException("E-UDF.CL.J-87: Column with name '" + name + "' does not exist");
+            throw new ExaIterationException("E-UDF.CL.SL.JAVA-1131: Column with name '" + name + "' does not exist");
         return getString(col);
     }
 
@@ -440,7 +440,7 @@ class ExaIteratorImpl implements ExaIterator {
             return (Boolean) object;
         else
             throw new ExaDataTypeException(
-                "E-UDF.CL.J-88: getBoolean cannot convert column '" + 
+                "E-UDF.CL.SL.JAVA-1132: getBoolean cannot convert column '" + 
                 columnNames.get(column) + 
                 "' of type " + 
                 exaMetadata.getInputColumnSqlType(column) + 
@@ -452,7 +452,7 @@ class ExaIteratorImpl implements ExaIterator {
     public Boolean getBoolean(String name) throws ExaIterationException, ExaDataTypeException {
         int col = columnNames.indexOf(name);
         if (col == -1)
-            throw new ExaIterationException("E-UDF.CL.J-89: Column with name '" + name + "' does not exist");
+            throw new ExaIterationException("E-UDF.CL.SL.JAVA-1133: Column with name '" + name + "' does not exist");
         return getBoolean(col);
     }
 
@@ -466,7 +466,7 @@ class ExaIteratorImpl implements ExaIterator {
         else
             throw 
               new ExaDataTypeException(
-                  "E-UDF.CL.J-90: getDate cannot convert column '" + 
+                  "E-UDF.CL.SL.JAVA-1134: getDate cannot convert column '" + 
                   columnNames.get(column) + 
                   "' of type " + 
                   exaMetadata.getInputColumnSqlType(column) + 
@@ -477,7 +477,7 @@ class ExaIteratorImpl implements ExaIterator {
     public Date getDate(String name) throws ExaIterationException, ExaDataTypeException {
         int col = columnNames.indexOf(name);
         if (col == -1)
-            throw new ExaIterationException("E-UDF.CL.J-91: Column with name '" + name + "' does not exist");
+            throw new ExaIterationException("E-UDF.CL.SL.JAVA-1135: Column with name '" + name + "' does not exist");
         return getDate(col);
     }
 
@@ -491,7 +491,7 @@ class ExaIteratorImpl implements ExaIterator {
         else
             throw 
               new ExaDataTypeException(
-                  "E-UDF.CL.J-92: getTimestamp cannot convert column '" + 
+                  "E-UDF.CL.SL.JAVA-1136: getTimestamp cannot convert column '" + 
                   columnNames.get(column) + 
                   "' of type " + 
                   exaMetadata.getInputColumnSqlType(column) + 
@@ -503,17 +503,17 @@ class ExaIteratorImpl implements ExaIterator {
     public Timestamp getTimestamp(String name) throws ExaIterationException, ExaDataTypeException {
         int col = columnNames.indexOf(name);
         if (col == -1)
-            throw new ExaIterationException("E-UDF.CL.J-93: Column with name '" + name + "' does not exist");
+            throw new ExaIterationException("E-UDF.CL.SL.JAVA-1137: Column with name '" + name + "' does not exist");
         return getTimestamp(col);
     }
 
     @Override
     public Object getObject(int column) throws ExaIterationException, ExaDataTypeException {
         if (column < 0 || column >= exaMetadata.getInputColumnCount())
-            throw new ExaIterationException("E-UDF.CL.J-94: Column number " + column + " does not exist");
+            throw new ExaIterationException("E-UDF.CL.SL.JAVA-1138: Column number " + column + " does not exist");
 
         if (finished)
-            throw new ExaIterationException("E-UDF.CL.J-95: Iteration finished");
+            throw new ExaIterationException("E-UDF.CL.SL.JAVA-1139: Iteration finished");
 
         if (cache[column] != null)
             return cache[column];
@@ -539,7 +539,7 @@ class ExaIteratorImpl implements ExaIterator {
                 try {
                     val = new String(utf8Bytes, "UTF-8");
                 } catch (java.io.UnsupportedEncodingException ex) {
-                    throw new ExaDataTypeException("F-UDF.CL.J-96: Column with name '" + columnNames.get(column) + "' contains invalid UTF-8 data");
+                    throw new ExaDataTypeException("F-UDF.CL.SL.JAVA-1140: Column with name '" + columnNames.get(column) + "' contains invalid UTF-8 data");
                 }
                 break;
             case "BOOLEAN":
@@ -556,7 +556,7 @@ class ExaIteratorImpl implements ExaIterator {
                     val = Timestamp.valueOf(timestamp);
                 break;
             default:
-                throw new ExaDataTypeException("F-UDF.CL.J-97: Column with name '" + columnNames.get(column) + "' has an invalid data type");
+                throw new ExaDataTypeException("F-UDF.CL.SL.JAVA-1141: Column with name '" + columnNames.get(column) + "' has an invalid data type");
         }
         if (tableIterator.wasNull())
             val = null;
@@ -568,7 +568,7 @@ class ExaIteratorImpl implements ExaIterator {
     public Object getObject(String name) throws ExaIterationException, ExaDataTypeException {
         int col = columnNames.indexOf(name);
         if (col == -1)
-            throw new ExaIterationException("E-UDF.CL.J-98: Column with name '" + name + "' does not exist");
+            throw new ExaIterationException("E-UDF.CL.SL.JAVA-1142: Column with name '" + name + "' does not exist");
         return getObject(col);
     }
 
@@ -579,33 +579,33 @@ class ExaIteratorImpl implements ExaIterator {
         if (from instanceof Long) {
             long val = (Long) from;
             if (val > Integer.MAX_VALUE)
-                throw new ExaDataTypeException("E-UDF.CL.J-99: emit column '" + name + "' has value of "
+                throw new ExaDataTypeException("E-UDF.CL.SL.JAVA-1143: emit column '" + name + "' has value of "
                             + val + " but column can only have maximum value of " + Integer.MAX_VALUE);
             if (val < Integer.MIN_VALUE)
-                throw new ExaDataTypeException("E-UDF.CL.J-100: emit column '" + name + "' has value of "
+                throw new ExaDataTypeException("E-UDF.CL.SL.JAVA-1144: emit column '" + name + "' has value of "
                             + val + " but column can only have minimum value of " + Integer.MIN_VALUE);
         }
         else if (from instanceof Float) {
             float val = (Float) from;
             if (val > Integer.MAX_VALUE)
-                throw new ExaDataTypeException("E-UDF.CL.J-101: emit column '" + name + "' has value of "
+                throw new ExaDataTypeException("E-UDF.CL.SL.JAVA-1145: emit column '" + name + "' has value of "
                             + val + " but column can only have maximum value of " + Integer.MAX_VALUE);
             if (val < Integer.MIN_VALUE)
-                throw new ExaDataTypeException("E-UDF.CL.J-102: emit column '" + name + "' has value of "
+                throw new ExaDataTypeException("E-UDF.CL.SL.JAVA-1146: emit column '" + name + "' has value of "
                             + val + " but column can only have minimum value of " + Integer.MIN_VALUE);
             if (val != Math.floor(val))
-                throw new ExaDataTypeException("E-UDF.CL.J-103: emit column '" + name + "' has a non-integer value of " + val);
+                throw new ExaDataTypeException("E-UDF.CL.SL.JAVA-1147: emit column '" + name + "' has a non-integer value of " + val);
         }
         else if (from instanceof Double) {
             double val = (Double) from;
             if (val > Integer.MAX_VALUE)
-                throw new ExaDataTypeException("E-UDF.CL.J-112: emit column '" + name + "' has value of "
+                throw new ExaDataTypeException("E-UDF.CL.SL.JAVA-1148: emit column '" + name + "' has value of "
                             + val + " but column can only have maximum value of " + Integer.MAX_VALUE);
             if (val < Integer.MIN_VALUE)
-                throw new ExaDataTypeException("E-UDF.CL.J-104: emit column '" + name + "' has value of "
+                throw new ExaDataTypeException("E-UDF.CL.SL.JAVA-1149: emit column '" + name + "' has value of "
                             + val + " but column can only have minimum value of " + Integer.MIN_VALUE);
             if (val != Math.floor(val))
-                throw new ExaDataTypeException("E-UDF.CL.J-105: emit column '" + name + "' has a non-integer value of " + val);
+                throw new ExaDataTypeException("E-UDF.CL.SL.JAVA-1150: emit column '" + name + "' has a non-integer value of " + val);
         }
 
         return true;
@@ -618,24 +618,24 @@ class ExaIteratorImpl implements ExaIterator {
         if (from instanceof Float) {
             float val = (Float) from;
             if (val > Long.MAX_VALUE)
-                throw new ExaDataTypeException("E-UDF.CL.J-106: emit column '" + name + "' has value of "
+                throw new ExaDataTypeException("E-UDF.CL.SL.JAVA-1151: emit column '" + name + "' has value of "
                             + val + " but column can only have maximum value of " + Long.MAX_VALUE);
             if (val < Long.MIN_VALUE)
-                throw new ExaDataTypeException("E-UDF.CL.J-107: emit column '" + name + "' has value of "
+                throw new ExaDataTypeException("E-UDF.CL.SL.JAVA-1152: emit column '" + name + "' has value of "
                             + val + " but column can only have minimum value of " + Long.MIN_VALUE);
             if (val != Math.floor(val))
-                throw new ExaDataTypeException("E-UDF.CL.J-108: emit column '" + name + "' has a non-integer value of " + val);
+                throw new ExaDataTypeException("E-UDF.CL.SL.JAVA-1153: emit column '" + name + "' has a non-integer value of " + val);
         }
         else if (from instanceof Double) {
             double val = (Double) from;
             if (val > Long.MAX_VALUE)
-                throw new ExaDataTypeException("E-UDF.CL.J-109: emit column '" + name + "' has value of "
+                throw new ExaDataTypeException("E-UDF.CL.SL.JAVA-1154: emit column '" + name + "' has value of "
                             + val + " but column can only have maximum value of " + Long.MAX_VALUE);
             if (val < Long.MIN_VALUE)
-                throw new ExaDataTypeException("E-UDF.CL.J-110: emit column '" + name + "' has value of "
+                throw new ExaDataTypeException("E-UDF.CL.SL.JAVA-1155: emit column '" + name + "' has value of "
                             + val + " but column can only have minimum value of " + Long.MIN_VALUE);
             if (val != Math.floor(val))
-                throw new ExaDataTypeException("E-UDF.CL.J-111: emit column '" + name + "' has a non-integer value of " + val);
+                throw new ExaDataTypeException("E-UDF.CL.SL.JAVA-1156: emit column '" + name + "' has a non-integer value of " + val);
         }
 
         return true;

--- a/exaudfclient/base/javacontainer/ExaMetadataImpl.java
+++ b/exaudfclient/base/javacontainer/ExaMetadataImpl.java
@@ -68,37 +68,37 @@ class ExaMetadataImpl implements ExaMetadata {
     @Override
     public String getInputColumnName(int column) throws ExaIterationException {
         if (column < 0 || column >= inputColumns.length)
-            throw new ExaIterationException("Column number " + column + " does not exist");
+            throw new ExaIterationException("E-UDF.CL.J-114: Column number " + column + " does not exist");
         return inputColumns[column].name;
     }
     @Override
     public Class<?> getInputColumnType(int column) throws ExaIterationException {
         if (column < 0 || column >= inputColumns.length)
-            throw new ExaIterationException("Column number " + column + " does not exist");
+            throw new ExaIterationException("E-UDF.CL.J-115: Column number " + column + " does not exist");
         return inputColumns[column].type;
     }
     @Override
     public String getInputColumnSqlType(int column) throws ExaIterationException {
         if (column < 0 || column >= inputColumns.length)
-            throw new ExaIterationException("Column number " + column + " does not exist");
+            throw new ExaIterationException("E-UDF.CL.J-116: Column number " + column + " does not exist");
         return inputColumns[column].sqlType;
     }
     @Override
     public long getInputColumnPrecision(int column) throws ExaIterationException {
         if (column < 0 || column >= inputColumns.length)
-            throw new ExaIterationException("Column number " + column + " does not exist");
+            throw new ExaIterationException("E-UDF.CL.J-117: Column number " + column + " does not exist");
         return inputColumns[column].precision;
     }
     @Override
     public long getInputColumnScale(int column) throws ExaIterationException {
         if (column < 0 || column >= inputColumns.length)
-            throw new ExaIterationException("Column number " + column + " does not exist");
+            throw new ExaIterationException("E-UDF.CL.J-118: Column number " + column + " does not exist");
         return inputColumns[column].scale;
     }
     @Override
     public long getInputColumnLength(int column) throws ExaIterationException {
         if (column < 0 || column >= inputColumns.length)
-            throw new ExaIterationException("Column number " + column + " does not exist");
+            throw new ExaIterationException("E-UDF.CL.J-119: Column number " + column + " does not exist");
         return inputColumns[column].length;
     }
     @Override
@@ -108,44 +108,44 @@ class ExaMetadataImpl implements ExaMetadata {
     @Override
     public String getOutputColumnName(int column) throws ExaIterationException {
         if (column < 0 || column >= outputColumns.length)
-            throw new ExaIterationException("Column number " + column + " does not exist");
+            throw new ExaIterationException("E-UDF.CL.J-120: Column number " + column + " does not exist");
         return outputColumns[column].name;
     }
     @Override
     public Class<?> getOutputColumnType(int column) throws ExaIterationException {
         if (column < 0 || column >= outputColumns.length)
-            throw new ExaIterationException("Column number " + column + " does not exist");
+            throw new ExaIterationException("E-UDF.CL.J-121: Column number " + column + " does not exist");
         return outputColumns[column].type;
     }
     @Override
     public String getOutputColumnSqlType(int column) throws ExaIterationException {
         if (column < 0 || column >= outputColumns.length)
-            throw new ExaIterationException("Column number " + column + " does not exist");
+            throw new ExaIterationException("E-UDF.CL.J-122: Column number " + column + " does not exist");
         return outputColumns[column].sqlType;
     }
     @Override
     public long getOutputColumnPrecision(int column) throws ExaIterationException {
         if (column < 0 || column >= outputColumns.length)
-            throw new ExaIterationException("Column number " + column + " does not exist");
+            throw new ExaIterationException("E-UDF.CL.J-123: Column number " + column + " does not exist");
         return outputColumns[column].precision;
     }
     @Override
     public long getOutputColumnScale(int column) throws ExaIterationException {
         if (column < 0 || column >= outputColumns.length)
-            throw new ExaIterationException("Column number " + column + " does not exist");
+            throw new ExaIterationException("E-UDF.CL.J-124: Column number " + column + " does not exist");
         return outputColumns[column].scale;
     }
     @Override
     public long getOutputColumnLength(int column) throws ExaIterationException {
         if (column < 0 || column >= outputColumns.length)
-            throw new ExaIterationException("Column number " + column + " does not exist");
+            throw new ExaIterationException("E-UDF.CL.J-125: Column number " + column + " does not exist");
         return outputColumns[column].length;
     }
     
     @Override
     public Class<?> importScript(String name) throws ExaCompilationException, ClassNotFoundException {
         if (name == null)
-            throw new ExaCompilationException("Script name is null");
+            throw new ExaCompilationException("F-UDF.CL.J-126: Script name is null");
         boolean isQuoted = (name.charAt(0) == '"' && name.charAt(name.length() - 1) == '"');
         String scriptName = isQuoted ? name.substring(1, name.length() - 1) : name.toUpperCase();
         if (!importedScripts.contains(scriptName)) {
@@ -153,9 +153,13 @@ class ExaMetadataImpl implements ExaMetadata {
             code = "package com.exasol;\r\n" + code;
             String exMsg = checkException();
             if (exMsg != null && exMsg.length() > 0) {
-                throw new ExaCompilationException(exMsg);
+                throw new ExaCompilationException("F-UDF.CL.J-127: "+exMsg);
             }
-            ExaCompiler.compile("com.exasol." + scriptName, code);
+            try:
+                ExaCompiler.compile("com.exasol." + scriptName, code);
+            catch(ExaCompilationException ex){
+                throw ExaCompilationException("F-UDF.CL.J-128: "+ex.toString())
+            }
             importedScripts.add(scriptName);
         }
         return Class.forName("com.exasol." + scriptName);
@@ -164,14 +168,14 @@ class ExaMetadataImpl implements ExaMetadata {
     @Override
     public ExaConnectionInformation getConnection(String name) throws ExaConnectionAccessException {
         if (name == null) {
-            throw new ExaConnectionAccessException("Connection name is null");
+            throw new ExaConnectionAccessException("E-UDF.CL.J-129: Connection name is null");
         }
         boolean isQuoted = (name.charAt(0) == '"' && name.charAt(name.length() - 1) == '"');
         String connectionName = isQuoted ? name.substring(1, name.length() - 1) : name.toUpperCase();
         ConnectionInformationWrapper w = metadata.connectionInformation(connectionName);
         String exMsg = checkException();
         if (exMsg != null && exMsg.length() > 0) {
-            throw new ExaConnectionAccessException(exMsg);
+            throw new ExaConnectionAccessException("E-UDF.CL.J-130: "+exMsg);
         }
         return new ExaConnectionInformationImpl(w.copyKind(), w.copyAddress(), w.copyUser(), w.copyPassword());
     }
@@ -294,7 +298,7 @@ class ExaMetadataImpl implements ExaMetadata {
                     length = 0;
                     break;
                 default:
-                    throw new ExaDataTypeException("data type " + exaType + " is not supported");
+                    throw new ExaDataTypeException("F-UDF.CL.J-131: data type " + exaType + " is not supported");
             }
         }
     }

--- a/exaudfclient/base/javacontainer/ExaMetadataImpl.java
+++ b/exaudfclient/base/javacontainer/ExaMetadataImpl.java
@@ -155,10 +155,10 @@ class ExaMetadataImpl implements ExaMetadata {
             if (exMsg != null && exMsg.length() > 0) {
                 throw new ExaCompilationException("F-UDF.CL.J-127: "+exMsg);
             }
-            try:
+            try{
                 ExaCompiler.compile("com.exasol." + scriptName, code);
-            catch(ExaCompilationException ex){
-                throw ExaCompilationException("F-UDF.CL.J-128: "+ex.toString())
+            }catch(ExaCompilationException ex){
+                throw new ExaCompilationException("F-UDF.CL.J-128: "+ex.toString());
             }
             importedScripts.add(scriptName);
         }

--- a/exaudfclient/base/javacontainer/ExaMetadataImpl.java
+++ b/exaudfclient/base/javacontainer/ExaMetadataImpl.java
@@ -68,37 +68,37 @@ class ExaMetadataImpl implements ExaMetadata {
     @Override
     public String getInputColumnName(int column) throws ExaIterationException {
         if (column < 0 || column >= inputColumns.length)
-            throw new ExaIterationException("E-UDF.CL.J-114: Column number " + column + " does not exist");
+            throw new ExaIterationException("E-UDF.CL.SL.JAVA-1083: Column number " + column + " does not exist");
         return inputColumns[column].name;
     }
     @Override
     public Class<?> getInputColumnType(int column) throws ExaIterationException {
         if (column < 0 || column >= inputColumns.length)
-            throw new ExaIterationException("E-UDF.CL.J-115: Column number " + column + " does not exist");
+            throw new ExaIterationException("E-UDF.CL.SL.JAVA-1084: Column number " + column + " does not exist");
         return inputColumns[column].type;
     }
     @Override
     public String getInputColumnSqlType(int column) throws ExaIterationException {
         if (column < 0 || column >= inputColumns.length)
-            throw new ExaIterationException("E-UDF.CL.J-116: Column number " + column + " does not exist");
+            throw new ExaIterationException("E-UDF.CL.SL.JAVA-1085: Column number " + column + " does not exist");
         return inputColumns[column].sqlType;
     }
     @Override
     public long getInputColumnPrecision(int column) throws ExaIterationException {
         if (column < 0 || column >= inputColumns.length)
-            throw new ExaIterationException("E-UDF.CL.J-117: Column number " + column + " does not exist");
+            throw new ExaIterationException("E-UDF.CL.SL.JAVA-1086: Column number " + column + " does not exist");
         return inputColumns[column].precision;
     }
     @Override
     public long getInputColumnScale(int column) throws ExaIterationException {
         if (column < 0 || column >= inputColumns.length)
-            throw new ExaIterationException("E-UDF.CL.J-118: Column number " + column + " does not exist");
+            throw new ExaIterationException("E-UDF.CL.SL.JAVA-1087: Column number " + column + " does not exist");
         return inputColumns[column].scale;
     }
     @Override
     public long getInputColumnLength(int column) throws ExaIterationException {
         if (column < 0 || column >= inputColumns.length)
-            throw new ExaIterationException("E-UDF.CL.J-119: Column number " + column + " does not exist");
+            throw new ExaIterationException("E-UDF.CL.SL.JAVA-1088: Column number " + column + " does not exist");
         return inputColumns[column].length;
     }
     @Override
@@ -108,44 +108,44 @@ class ExaMetadataImpl implements ExaMetadata {
     @Override
     public String getOutputColumnName(int column) throws ExaIterationException {
         if (column < 0 || column >= outputColumns.length)
-            throw new ExaIterationException("E-UDF.CL.J-120: Column number " + column + " does not exist");
+            throw new ExaIterationException("E-UDF.CL.SL.JAVA-1089: Column number " + column + " does not exist");
         return outputColumns[column].name;
     }
     @Override
     public Class<?> getOutputColumnType(int column) throws ExaIterationException {
         if (column < 0 || column >= outputColumns.length)
-            throw new ExaIterationException("E-UDF.CL.J-121: Column number " + column + " does not exist");
+            throw new ExaIterationException("E-UDF.CL.SL.JAVA-1090: Column number " + column + " does not exist");
         return outputColumns[column].type;
     }
     @Override
     public String getOutputColumnSqlType(int column) throws ExaIterationException {
         if (column < 0 || column >= outputColumns.length)
-            throw new ExaIterationException("E-UDF.CL.J-122: Column number " + column + " does not exist");
+            throw new ExaIterationException("E-UDF.CL.SL.JAVA-1091: Column number " + column + " does not exist");
         return outputColumns[column].sqlType;
     }
     @Override
     public long getOutputColumnPrecision(int column) throws ExaIterationException {
         if (column < 0 || column >= outputColumns.length)
-            throw new ExaIterationException("E-UDF.CL.J-123: Column number " + column + " does not exist");
+            throw new ExaIterationException("E-UDF.CL.SL.JAVA-1092: Column number " + column + " does not exist");
         return outputColumns[column].precision;
     }
     @Override
     public long getOutputColumnScale(int column) throws ExaIterationException {
         if (column < 0 || column >= outputColumns.length)
-            throw new ExaIterationException("E-UDF.CL.J-124: Column number " + column + " does not exist");
+            throw new ExaIterationException("E-UDF.CL.SL.JAVA-1093: Column number " + column + " does not exist");
         return outputColumns[column].scale;
     }
     @Override
     public long getOutputColumnLength(int column) throws ExaIterationException {
         if (column < 0 || column >= outputColumns.length)
-            throw new ExaIterationException("E-UDF.CL.J-125: Column number " + column + " does not exist");
+            throw new ExaIterationException("E-UDF.CL.SL.JAVA-1094: Column number " + column + " does not exist");
         return outputColumns[column].length;
     }
     
     @Override
     public Class<?> importScript(String name) throws ExaCompilationException, ClassNotFoundException {
         if (name == null)
-            throw new ExaCompilationException("F-UDF.CL.J-126: Script name is null");
+            throw new ExaCompilationException("F-UDF.CL.SL.JAVA-1095: Script name is null");
         boolean isQuoted = (name.charAt(0) == '"' && name.charAt(name.length() - 1) == '"');
         String scriptName = isQuoted ? name.substring(1, name.length() - 1) : name.toUpperCase();
         if (!importedScripts.contains(scriptName)) {
@@ -153,12 +153,12 @@ class ExaMetadataImpl implements ExaMetadata {
             code = "package com.exasol;\r\n" + code;
             String exMsg = checkException();
             if (exMsg != null && exMsg.length() > 0) {
-                throw new ExaCompilationException("F-UDF.CL.J-127: "+exMsg);
+                throw new ExaCompilationException("F-UDF.CL.SL.JAVA-1096: "+exMsg);
             }
             try{
                 ExaCompiler.compile("com.exasol." + scriptName, code);
             }catch(ExaCompilationException ex){
-                throw new ExaCompilationException("F-UDF.CL.J-128: "+ex.toString());
+                throw new ExaCompilationException("F-UDF.CL.SL.JAVA-1097: "+ex.toString());
             }
             importedScripts.add(scriptName);
         }
@@ -168,14 +168,14 @@ class ExaMetadataImpl implements ExaMetadata {
     @Override
     public ExaConnectionInformation getConnection(String name) throws ExaConnectionAccessException {
         if (name == null) {
-            throw new ExaConnectionAccessException("E-UDF.CL.J-129: Connection name is null");
+            throw new ExaConnectionAccessException("E-UDF.CL.SL.JAVA-1098: Connection name is null");
         }
         boolean isQuoted = (name.charAt(0) == '"' && name.charAt(name.length() - 1) == '"');
         String connectionName = isQuoted ? name.substring(1, name.length() - 1) : name.toUpperCase();
         ConnectionInformationWrapper w = metadata.connectionInformation(connectionName);
         String exMsg = checkException();
         if (exMsg != null && exMsg.length() > 0) {
-            throw new ExaConnectionAccessException("E-UDF.CL.J-130: "+exMsg);
+            throw new ExaConnectionAccessException("E-UDF.CL.SL.JAVA-1099: "+exMsg);
         }
         return new ExaConnectionInformationImpl(w.copyKind(), w.copyAddress(), w.copyUser(), w.copyPassword());
     }
@@ -298,7 +298,7 @@ class ExaMetadataImpl implements ExaMetadata {
                     length = 0;
                     break;
                 default:
-                    throw new ExaDataTypeException("F-UDF.CL.J-131: data type " + exaType + " is not supported");
+                    throw new ExaDataTypeException("F-UDF.CL.SL.JAVA-1100: data type " + exaType + " is not supported");
             }
         }
     }

--- a/exaudfclient/base/javacontainer/ExaUDFException.java
+++ b/exaudfclient/base/javacontainer/ExaUDFException.java
@@ -1,0 +1,12 @@
+package com.exasol;
+
+/**
+ * This exception indicates that an exception during the execution of user code happend.
+ */
+public class ExaUDFException extends Exception {
+    private static final long serialVersionUID = 1L;
+    public ExaUDFException() { super(); }
+    public ExaUDFException(String message) { super(message); }
+    public ExaUDFException(String message, Throwable cause) { super(message, cause); }
+    public ExaUDFException(Throwable cause) { super(cause); }
+}

--- a/exaudfclient/base/javacontainer/ExaWrapper.java
+++ b/exaudfclient/base/javacontainer/ExaWrapper.java
@@ -69,7 +69,7 @@ class ExaWrapper {
                  // args is already a String with the String arg, so nothing to do
                  argClass = String.class;
              } else {
-                 throw new ExaCompilationException("F-UDF.CL.J-39: Internal error: single call argument with unknown DTO: " + args.toString());
+                 throw new ExaCompilationException("F-UDF.CL.SL.JAVA-1065: Internal error: single call argument with unknown DTO: " + args.toString());
              }
         }
 
@@ -102,12 +102,12 @@ class ExaWrapper {
             }
         } catch (java.lang.ClassNotFoundException ex) {
             if (userDefinedScriptName) {
-                throw new ExaCompilationException("F-UDF.CL.J-40: The main script class defined via %scriptclass cannot be found: " + scriptClassName);
+                throw new ExaCompilationException("F-UDF.CL.SL.JAVA-1066: The main script class defined via %scriptclass cannot be found: " + scriptClassName);
             } else {
-                throw new ExaCompilationException("F-UDF.CL.J-41: The main script class (same name as the script) cannot be found: " + scriptClassName + ". Please create the class or specify the class via %scriptclass.");
+                throw new ExaCompilationException("F-UDF.CL.SL.JAVA-1067: The main script class (same name as the script) cannot be found: " + scriptClassName + ". Please create the class or specify the class via %scriptclass.");
             }
         } catch (InvocationTargetException ex) {
-              throw convertReflectiveExceptionToCause("F-UDF.CL.J-42","Exception during singleCall "+fn,ex);
+              throw convertReflectiveExceptionToCause("F-UDF.CL.SL.JAVA-1068","Exception during singleCall "+fn,ex);
         } catch (NoSuchMethodException ex) {
            throw new ExaUndefinedSingleCallException(fn);
         }
@@ -117,17 +117,17 @@ class ExaWrapper {
         ExaMetadataImpl exaMetadata = new ExaMetadataImpl();
         String exMsg = exaMetadata.checkException();
         if (exMsg != null && exMsg.length() > 0) {
-            throw new ExaIterationException("F-UDF.CL.J-43: "+exMsg);
+            throw new ExaIterationException("F-UDF.CL.SL.JAVA-1069: "+exMsg);
         }
         TableIterator tableIterator = new TableIterator();
         exMsg = tableIterator.checkException();
         if (exMsg != null && exMsg.length() > 0) {
-            throw new ExaIterationException("F-UDF.CL.J-44: "+exMsg);
+            throw new ExaIterationException("F-UDF.CL.SL.JAVA-1070: "+exMsg);
         }
         ResultHandler resultHandler = new ResultHandler(tableIterator);
         exMsg = resultHandler.checkException();
         if (exMsg != null && exMsg.length() > 0) {
-            throw new ExaIterationException("F-UDF.CL.J-45: "+exMsg);
+            throw new ExaIterationException("F-UDF.CL.SL.JAVA-1071: "+exMsg);
         }
 
         ExaIteratorImpl exaIter = new ExaIteratorImpl(exaMetadata, tableIterator, resultHandler);
@@ -152,14 +152,14 @@ class ExaWrapper {
         }
         catch (java.lang.ClassNotFoundException ex) {
             if (userDefinedScriptName) {
-                throw new ExaCompilationException("F-UDF.CL.J-46: The main script class defined via %scriptclass cannot be found: " + scriptClassName);
+                throw new ExaCompilationException("F-UDF.CL.SL.JAVA-1072: The main script class defined via %scriptclass cannot be found: " + scriptClassName);
             } else {
-                throw new ExaCompilationException("F-UDF.CL.J-47: The main script class (same name as the script) cannot be found: " + scriptClassName + ". Please create the class or specify the class via %scriptclass.");
+                throw new ExaCompilationException("F-UDF.CL.SL.JAVA-1073: The main script class (same name as the script) cannot be found: " + scriptClassName + ". Please create the class or specify the class via %scriptclass.");
             }
         } catch (InvocationTargetException ex) {
-            throw convertReflectiveExceptionToCause("F-UDF.CL.J-54","Exception during init",ex);
+            throw convertReflectiveExceptionToCause("F-UDF.CL.SL.JAVA-1074","Exception during init",ex);
         } catch (NoSuchMethodException ex) { 
-            System.err.println("W-UDF.CL.J-48: Skipping init, because init method cannot be found.");
+            System.err.println("W-UDF.CL.SL.JAVA-1075: Skipping init, because init method cannot be found.");
         }
 
         // run()
@@ -170,14 +170,14 @@ class ExaWrapper {
             if (exaMetadata.getInputType().equals("SET")) { // MULTIPLE INPUT
                 if (exaMetadata.getOutputType().equals("EMIT")) { // MULTIPLE OUTPUT
                     if (!runMethod.getReturnType().equals(Void.TYPE))
-                        throw new ExaCompilationException("F-UDF.CL.J-49: EMITS requires a void return type for run()");
+                        throw new ExaCompilationException("F-UDF.CL.SL.JAVA-1076: EMITS requires a void return type for run()");
                     exaIter.setInsideRun(true);
                     Object returnValue = runMethod.invoke(null, exaMetadata, exaIter);
                     exaIter.setInsideRun(false);
                 }
                 else { // EXACTLY_ONCE OUTPUT
                     if (runMethod.getReturnType().equals(Void.TYPE))
-                        throw new ExaCompilationException("F-UDF.CL.J-50: RETURNS requires a non-void return type for run()");
+                        throw new ExaCompilationException("F-UDF.CL.SL.JAVA-1077: RETURNS requires a non-void return type for run()");
                     exaIter.setInsideRun(true);
                     Object returnValue = runMethod.invoke(null, exaMetadata, exaIter);
                     exaIter.setInsideRun(false);
@@ -187,7 +187,7 @@ class ExaWrapper {
             else { // EXACTLY_ONCE INPUT
                 if (exaMetadata.getOutputType().equals("EMIT")) { // MULTIPLE OUTPUT
                     if (!runMethod.getReturnType().equals(Void.TYPE))
-                        throw new ExaCompilationException("F-UDF.CL.J-51: EMITS requires a void return type for run()");
+                        throw new ExaCompilationException("F-UDF.CL.SL.JAVA-1078: EMITS requires a void return type for run()");
                     do {
                         exaIter.setInsideRun(true);
                         Object returnValue = runMethod.invoke(null, exaMetadata, exaIter);
@@ -196,7 +196,7 @@ class ExaWrapper {
                 }
                 else { // EXACTLY_ONCE OUTPUT
                     if (runMethod.getReturnType().equals(Void.TYPE))
-                        throw new ExaCompilationException("F-UDF.CL.J-52: RETURNS requires a non-void return type for run()");
+                        throw new ExaCompilationException("F-UDF.CL.SL.JAVA-1079: RETURNS requires a non-void return type for run()");
                     do {
                         exaIter.setInsideRun(true);
                         Object returnValue = runMethod.invoke(null, exaMetadata, exaIter);
@@ -207,7 +207,7 @@ class ExaWrapper {
             }
         }
         catch (InvocationTargetException ex) {
-            throw convertReflectiveExceptionToCause("F-UDF.CL.J-55","Exception during run",ex);
+            throw convertReflectiveExceptionToCause("F-UDF.CL.SL.JAVA-1080","Exception during run",ex);
         }
 
         resultHandler.flush();
@@ -220,10 +220,10 @@ class ExaWrapper {
             cleanupMethod.invoke(null, exaMetadata);
         }
         catch (InvocationTargetException ex) {
-            throw convertReflectiveExceptionToCause("F-UDF.CL.J-56","Exception during cleanup",ex);
+            throw convertReflectiveExceptionToCause("F-UDF.CL.SL.JAVA-1081","Exception during cleanup",ex);
         }
         catch (NoSuchMethodException ex) {
-            System.err.println("W-UDF.CL.J-53: Skipping init, because init method cannot be found.");
+            System.err.println("W-UDF.CL.SL.JAVA-1082: Skipping init, because init method cannot be found.");
         }
     }
 

--- a/exaudfclient/base/javacontainer/ExaWrapper.java
+++ b/exaudfclient/base/javacontainer/ExaWrapper.java
@@ -1,6 +1,8 @@
 package com.exasol;
 
 import java.io.IOError;
+import java.io.StringWriter;
+import java.io.PrintWriter;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.MalformedParameterizedTypeException;
 import java.lang.reflect.Method;
@@ -228,6 +230,9 @@ class ExaWrapper {
             else
                 exc = cause;
         }
-        return exc;
+        StringWriter sw = new StringWriter();
+        PrintWriter pw = new PrintWriter(sw);
+        exc.printStackTrace(pw);
+        return new Exception(sw.toString());
     }
 }

--- a/exaudfclient/base/javacontainer/ExaWrapper.java
+++ b/exaudfclient/base/javacontainer/ExaWrapper.java
@@ -224,7 +224,7 @@ class ExaWrapper {
         }
     }
 
-    private static Throwable convertReflectiveExceptionToCause(string error_code, Throwable ex) {
+    private static Throwable convertReflectiveExceptionToCause(String error_code, Throwable ex) {
         Throwable exc = ex;
         while (exc != null && (exc instanceof InvocationTargetException ||
                     exc instanceof MalformedParameterizedTypeException ||

--- a/exaudfclient/base/javacontainer/javacontainer.cc
+++ b/exaudfclient/base/javacontainer/javacontainer.cc
@@ -25,11 +25,12 @@ class SWIGVMContainers::JavaVMImpl {
         void createJvm();
         void addPackageToScript();
         void compileScript();
-        bool check(string& calledUndefinedSingleCall); // returns 0 if the check failed
+        bool check(const string& errorCode, string& calledUndefinedSingleCall); // returns 0 if the check failed
         void registerFunctions();
         void setClasspath();
         void throwException(const char *message);
-        void throwException(std::exception& ex);
+        void throwException(const std::exception& ex);
+        void throwException(const std::string& ex);
         //void throwException(swig_undefined_single_call_exception& ex);
         void importScripts();
         void addExternalJarPaths();
@@ -133,15 +134,15 @@ bool JavaVMImpl::run() {
         throwException("F-UDF.CL.J-9: Java VM in check only mode");
     jclass cls = m_env->FindClass("com/exasol/ExaWrapper");
     string calledUndefinedSingleCall;
-    check(calledUndefinedSingleCall);
+    check("F-UDF.CL.J-133",calledUndefinedSingleCall);
     if (!cls)
         throwException("F-UDF.CL.J-10: FindClass for ExaWrapper failed");
     jmethodID mid = m_env->GetStaticMethodID(cls, "run", "()V");
-    check(calledUndefinedSingleCall);
+    check("F-UDF.CL.J-134",calledUndefinedSingleCall);
     if (!mid)
         throwException("F-UDF.CL.J-11: GetStaticMethodID for run failed");
     m_env->CallStaticVoidMethod(cls, mid);
-    check(calledUndefinedSingleCall);
+    check("F-UDF.CL.J-135",calledUndefinedSingleCall);
     return true;
 }
 
@@ -164,15 +165,15 @@ const char* JavaVMImpl::singleCall(single_call_function_id_e fn, const Execution
         throwException("F-UDF.CL.J-13: Unknown single call "+std::to_string(fn));
     }
     jclass cls = m_env->FindClass("com/exasol/ExaWrapper");
-    check(calledUndefinedSingleCall);
+    check("F-UDF.CL.J-136",calledUndefinedSingleCall);
     if (!cls)
         throwException("F-UDF.CL.J-14: FindClass for ExaWrapper failed");
     jmethodID mid = m_env->GetStaticMethodID(cls, "runSingleCall", "(Ljava/lang/String;Ljava/lang/Object;)[B");
-    check(calledUndefinedSingleCall);
+    check("F-UDF.CL.J-137",calledUndefinedSingleCall);
     if (!mid)
         throwException("F-UDF.CL.J-15: GetStaticMethodID for run failed");
     jstring fn_js = m_env->NewStringUTF(func);
-    check(calledUndefinedSingleCall);
+    check("F-UDF.CL.J-138",calledUndefinedSingleCall);
 
 
     // Prepare arg
@@ -189,9 +190,9 @@ const char* JavaVMImpl::singleCall(single_call_function_id_e fn, const Execution
         if (imp_spec)
         {         
             jclass import_spec_wrapper_cls = m_env->FindClass("com/exasol/swig/ImportSpecificationWrapper");
-            check(calledUndefinedSingleCall);
+            check("F-UDF.CL.J-139",calledUndefinedSingleCall);
             jmethodID import_spec_wrapper_constructor = m_env->GetMethodID(import_spec_wrapper_cls, "<init>", "(JZ)V");
-            check(calledUndefinedSingleCall);
+            check("F-UDF.CL.J-140",calledUndefinedSingleCall);
             args_js = m_env->NewObject(import_spec_wrapper_cls, import_spec_wrapper_constructor, &imp_spec_wrapper, false);
         }
     } else if (fn == SC_FN_GENERATE_SQL_FOR_EXPORT_SPEC) {
@@ -200,9 +201,9 @@ const char* JavaVMImpl::singleCall(single_call_function_id_e fn, const Execution
         if (exp_spec)
         {
             jclass export_spec_wrapper_cls = m_env->FindClass("com/exasol/swig/ExportSpecificationWrapper");
-            check(calledUndefinedSingleCall);
+            check("F-UDF.CL.J-141",calledUndefinedSingleCall);
             jmethodID export_spec_wrapper_constructor = m_env->GetMethodID(export_spec_wrapper_cls, "<init>", "(JZ)V");
-            check(calledUndefinedSingleCall);
+            check("F-UDF.CL.J-142",calledUndefinedSingleCall);
             args_js = m_env->NewObject(export_spec_wrapper_cls, export_spec_wrapper_constructor, &exp_spec_wrapper, false);
         }
     } else if (fn == SC_FN_VIRTUAL_SCHEMA_ADAPTER_CALL) {
@@ -211,11 +212,11 @@ const char* JavaVMImpl::singleCall(single_call_function_id_e fn, const Execution
         args_js = m_env->NewStringUTF(string_arg.c_str());
     }
     
-    check(calledUndefinedSingleCall);
+    check("F-UDF.CL.J-143",calledUndefinedSingleCall);
     jbyteArray resJ = (jbyteArray)m_env->CallStaticObjectMethod(cls, mid, fn_js, args_js);
-    if (check(calledUndefinedSingleCall) == 0) return strdup("<error during singleCall>");
+    if (check("F-UDF.CL.J-144",calledUndefinedSingleCall) == 0) return strdup("<error during singleCall>");
     jsize resLen = m_env->GetArrayLength(resJ);
-    check(calledUndefinedSingleCall);
+    check("F-UDF.CL.J-145",calledUndefinedSingleCall);
     char* buffer = new char[resLen + 1];
     m_env->GetByteArrayRegion(resJ, 0, resLen, reinterpret_cast<jbyte*>(buffer));
     buffer[resLen] = '\0';
@@ -278,23 +279,23 @@ void JavaVMImpl::createJvm() {
 void JavaVMImpl::compileScript() {
     string calledUndefinedSingleCall;
     jstring classnameStr = m_env->NewStringUTF(SWIGVM_params->script_name);
-    check(calledUndefinedSingleCall);
+    check("F-UDF.CL.J-146",calledUndefinedSingleCall);
     jstring codeStr = m_env->NewStringUTF(m_scriptCode.c_str());
-    check(calledUndefinedSingleCall);
+    check("F-UDF.CL.J-147",calledUndefinedSingleCall);
     jstring classpathStr = m_env->NewStringUTF(m_localClasspath.c_str());
-    check(calledUndefinedSingleCall);
+    check("F-UDF.CL.J-148",calledUndefinedSingleCall);
     if (!classnameStr || !codeStr || !classpathStr)
         throwException("F-UDF.CL.J-17: NewStringUTF for compile failed");
     jclass cls = m_env->FindClass("com/exasol/ExaCompiler");
-    check(calledUndefinedSingleCall);
+    check("F-UDF.CL.J-149",calledUndefinedSingleCall);
     if (!cls)
         throwException("F-UDF.CL.J-18: FindClass for ExaCompiler failed");
     jmethodID mid = m_env->GetStaticMethodID(cls, "compile", "(Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V");
-    check(calledUndefinedSingleCall);
+    check("F-UDF.CL.J-150",calledUndefinedSingleCall);
     if (!mid)
         throwException("F-UDF.CL.J-19: GetStaticMethodID for compile failed");
     m_env->CallStaticVoidMethod(cls, mid, classnameStr, codeStr, classpathStr);
-    check(calledUndefinedSingleCall);
+    check("F-UDF.CL.J-151",calledUndefinedSingleCall);
 }
 
 void JavaVMImpl::addExternalJarPaths() {
@@ -386,7 +387,7 @@ void JavaVMImpl::importScripts() {
         delete meta;
 }
 
-bool JavaVMImpl::check(string& calledUndefinedSingleCall, string& errorCode) {
+bool JavaVMImpl::check(const string& errorCode, string& calledUndefinedSingleCall) {
     jthrowable ex = m_env->ExceptionOccurred();
     if (ex) {
         m_env->ExceptionClear();
@@ -397,7 +398,7 @@ bool JavaVMImpl::check(string& calledUndefinedSingleCall, string& errorCode) {
         }
         if (m_env->IsInstanceOf(ex, undefinedSingleCallExceptionClass)) {
             jmethodID undefinedRemoteFn = m_env->GetMethodID(undefinedSingleCallExceptionClass, "getUndefinedRemoteFn", "()Ljava/lang/String;");
-            check(calledUndefinedSingleCall);
+            check("F-UDF.CL.J-152",calledUndefinedSingleCall);
             if (!undefinedRemoteFn)
                 throwException(errorCode+": F-UDF.CL.J-24: com.exasol.ExaUndefinedSingleCallException.getUndefinedRemoteFn() could not be found");
             jobject undefinedRemoteFnString = m_env->CallObjectMethod(ex,undefinedRemoteFn);
@@ -421,7 +422,7 @@ bool JavaVMImpl::check(string& calledUndefinedSingleCall, string& errorCode) {
             throwException(errorCode+": F-UDF.CL.J-26: FindClass for Throwable failed");
         // Throwable.toString()
         jmethodID toString = m_env->GetMethodID(exClass, "toString", "()Ljava/lang/String;");
-        check(calledUndefinedSingleCall);
+        check("F-UDF.CL.J-153",calledUndefinedSingleCall);
         if (!toString)
             throwException(errorCode+": F-UDF.CL.J-27: Throwable.toString() could not be found");
         jobject object = m_env->CallObjectMethod(ex, toString);
@@ -437,23 +438,23 @@ bool JavaVMImpl::check(string& calledUndefinedSingleCall, string& errorCode) {
         }
         // Throwable.getStackTrace()
         jmethodID getStackTrace = m_env->GetMethodID(exClass, "getStackTrace", "()[Ljava/lang/StackTraceElement;");
-        check(calledUndefinedSingleCall);
+        check("F-UDF.CL.J-154",calledUndefinedSingleCall);
         if (!getStackTrace)
             throwException(errorCode+": F-UDF.CL.J-29: Throwable.getStackTrace() could not be found");
         jobjectArray frames = (jobjectArray)m_env->CallObjectMethod(ex, getStackTrace);
         if (frames) {
             jclass frameClass = m_env->FindClass("java/lang/StackTraceElement");
-            check(calledUndefinedSingleCall);
+            check("F-UDF.CL.J-155",calledUndefinedSingleCall);
             if (!frameClass)
                 throwException(errorCode+": F-UDF.CL.J-30: FindClass for StackTraceElement failed");
             jmethodID frameToString = m_env->GetMethodID(frameClass, "toString", "()Ljava/lang/String;");
-            check(calledUndefinedSingleCall);
+            check("F-UDF.CL.J-156",calledUndefinedSingleCall);
             if (!frameToString)
                 throwException(errorCode+": F-UDF.CL.J-31: StackTraceElement.toString() could not be found");
             jsize framesLength = m_env->GetArrayLength(frames);
             for (int i = 0; i < framesLength; i++) {
                 jobject frame = m_env->GetObjectArrayElement(frames, i);
-                check(calledUndefinedSingleCall);
+                check("F-UDF.CL.J-157",calledUndefinedSingleCall);
                 jobject frameMsgObj = m_env->CallObjectMethod(frame, frameToString);
                 if (frameMsgObj) {
                     jstring message = static_cast<jstring>(frameMsgObj);
@@ -484,11 +485,11 @@ bool JavaVMImpl::check(string& calledUndefinedSingleCall, string& errorCode) {
 void JavaVMImpl::registerFunctions() {
     string calledUndefinedSingleCall;
     jclass cls = m_env->FindClass("com/exasol/swig/exascript_javaJNI");
-    check(calledUndefinedSingleCall);
+    check("F-UDF.CL.J-158",calledUndefinedSingleCall);
     if (!cls)
         throwException("F-UDF.CL.J-32: FindClass for exascript_javaJNI failed");
     int rc = m_env->RegisterNatives(cls, methods, sizeof(methods) / sizeof(methods[0]));
-    check(calledUndefinedSingleCall);
+    check("F-UDF.CL.J-159",calledUndefinedSingleCall);
     if (rc)
         throwException("F-UDF.CL.J-33: RegisterNatives failed");
 }
@@ -616,22 +617,22 @@ void JavaVMImpl::setJvmOptions() {
 }
 
 
-
-void JavaVMImpl::throwException(const char *message) {
+void JavaVMImpl::throwException(const std::string&  message) {
     if (!m_exceptionThrown) {
         m_exceptionThrown = true;
     }
     throw JavaVMach::exception(message);
 }
 
-void JavaVMImpl::throwException(std::string&  message) {
+
+void JavaVMImpl::throwException(const char*  message) {
     if (!m_exceptionThrown) {
         m_exceptionThrown = true;
     }
     throw JavaVMach::exception(message);
 }
 
-void JavaVMImpl::throwException(std::exception& ex) {
+void JavaVMImpl::throwException(const std::exception& ex) {
     if (!m_exceptionThrown) {
         m_exceptionThrown = true;
     }

--- a/exaudfclient/base/javacontainer/javacontainer.cc
+++ b/exaudfclient/base/javacontainer/javacontainer.cc
@@ -58,10 +58,10 @@ JavaVMach::JavaVMach(bool checkOnly) {
         m_impl = new JavaVMImpl(checkOnly);
     } catch (std::exception& err) {
         lock_guard<mutex> lock(exception_msg_mtx);
-        exception_msg = "F-UDF.CL.J-1: "+std::string(err.what());
+        exception_msg = "F-UDF.CL.SL.JAVA-1000: "+std::string(err.what());
     } catch (...) {
         lock_guard<mutex> lock(exception_msg_mtx);
-        exception_msg = "F-UDF.CL.J-2: some unknown exception occurred";
+        exception_msg = "F-UDF.CL.SL.JAVA-1001: some unknown exception occurred";
     }
 }
 
@@ -71,10 +71,10 @@ bool JavaVMach::run() {
         return m_impl->run();
     }  catch (std::exception& err) {
         lock_guard<mutex> lock(exception_msg_mtx);
-        exception_msg = "F-UDF.CL.J-3: "+std::string(err.what());
+        exception_msg = "F-UDF.CL.SL.JAVA-1002: "+std::string(err.what());
     } catch (...) {
         lock_guard<mutex> lock(exception_msg_mtx);
-        exception_msg = "F-UDF.CL.J-4: some unknown exception occurred";
+        exception_msg = "F-UDF.CL.SL.JAVA-1003: some unknown exception occurred";
     }
     return false;
 }
@@ -84,10 +84,10 @@ void JavaVMach::shutdown() {
         m_impl->shutdown();
     }  catch (std::exception& err) {
         lock_guard<mutex> lock(exception_msg_mtx);
-        exception_msg = "F-UDF.CL.J-5: "+std::string(err.what());
+        exception_msg = "F-UDF.CL.SL.JAVA-1004: "+std::string(err.what());
     } catch (...) {
         lock_guard<mutex> lock(exception_msg_mtx);
-        exception_msg = "F-UDF.CL.J-6: some unknown exception occurred";
+        exception_msg = "F-UDF.CL.SL.JAVA-1005: some unknown exception occurred";
     }
 }
 
@@ -96,10 +96,10 @@ const char* JavaVMach::singleCall(single_call_function_id_e fn, const ExecutionG
         return m_impl->singleCall(fn, args, calledUndefinedSingleCall);
     } catch (std::exception& err) {
         lock_guard<mutex> lock(exception_msg_mtx);
-        exception_msg = "F-UDF.CL.J-7: "+std::string(err.what());
+        exception_msg = "F-UDF.CL.SL.JAVA-1006: "+std::string(err.what());
     } catch (...) {
         lock_guard<mutex> lock(exception_msg_mtx);
-        exception_msg = "F-UDF.CL.J-8: some unknown exception occurred";
+        exception_msg = "F-UDF.CL.SL.JAVA-1007: some unknown exception occurred";
     }
     return strdup("<this is an error>");
 }
@@ -131,18 +131,18 @@ void JavaVMImpl::shutdown() {
 
 bool JavaVMImpl::run() {
     if (m_checkOnly)
-        throwException("F-UDF.CL.J-9: Java VM in check only mode");
+        throwException("F-UDF.CL.SL.JAVA-1008: Java VM in check only mode");
     jclass cls = m_env->FindClass("com/exasol/ExaWrapper");
     string calledUndefinedSingleCall;
-    check("F-UDF.CL.J-133",calledUndefinedSingleCall);
+    check("F-UDF.CL.SL.JAVA-1009",calledUndefinedSingleCall);
     if (!cls)
-        throwException("F-UDF.CL.J-10: FindClass for ExaWrapper failed");
+        throwException("F-UDF.CL.SL.JAVA-1010: FindClass for ExaWrapper failed");
     jmethodID mid = m_env->GetStaticMethodID(cls, "run", "()V");
-    check("F-UDF.CL.J-134",calledUndefinedSingleCall);
+    check("F-UDF.CL.SL.JAVA-1011",calledUndefinedSingleCall);
     if (!mid)
-        throwException("F-UDF.CL.J-11: GetStaticMethodID for run failed");
+        throwException("F-UDF.CL.SL.JAVA-1012: GetStaticMethodID for run failed");
     m_env->CallStaticVoidMethod(cls, mid);
-    check("F-UDF.CL.J-135",calledUndefinedSingleCall);
+    check("F-UDF.CL.SL.JAVA-1013",calledUndefinedSingleCall);
     return true;
 }
 
@@ -151,7 +151,7 @@ static string singleCallResult;
 const char* JavaVMImpl::singleCall(single_call_function_id_e fn, const ExecutionGraph::ScriptDTO& args, string& calledUndefinedSingleCall) {
 
     if (m_checkOnly)
-        throwException("F-UDF.CL.J-12: Java VM in check only mode");
+        throwException("F-UDF.CL.SL.JAVA-1014: Java VM in check only mode");
 
     const char* func = NULL;
     switch (fn) {
@@ -162,18 +162,18 @@ const char* JavaVMImpl::singleCall(single_call_function_id_e fn, const Execution
         case SC_FN_GENERATE_SQL_FOR_EXPORT_SPEC: func = "generateSqlForExportSpec"; break;
     }
     if (func == NULL) {
-        throwException("F-UDF.CL.J-13: Unknown single call "+std::to_string(fn));
+        throwException("F-UDF.CL.SL.JAVA-1015: Unknown single call "+std::to_string(fn));
     }
     jclass cls = m_env->FindClass("com/exasol/ExaWrapper");
-    check("F-UDF.CL.J-136",calledUndefinedSingleCall);
+    check("F-UDF.CL.SL.JAVA-1016",calledUndefinedSingleCall);
     if (!cls)
-        throwException("F-UDF.CL.J-14: FindClass for ExaWrapper failed");
+        throwException("F-UDF.CL.SL.JAVA-1017: FindClass for ExaWrapper failed");
     jmethodID mid = m_env->GetStaticMethodID(cls, "runSingleCall", "(Ljava/lang/String;Ljava/lang/Object;)[B");
-    check("F-UDF.CL.J-137",calledUndefinedSingleCall);
+    check("F-UDF.CL.SL.JAVA-1018",calledUndefinedSingleCall);
     if (!mid)
-        throwException("F-UDF.CL.J-15: GetStaticMethodID for run failed");
+        throwException("F-UDF.CL.SL.JAVA-1019: GetStaticMethodID for run failed");
     jstring fn_js = m_env->NewStringUTF(func);
-    check("F-UDF.CL.J-138",calledUndefinedSingleCall);
+    check("F-UDF.CL.SL.JAVA-1020",calledUndefinedSingleCall);
 
 
     // Prepare arg
@@ -190,9 +190,9 @@ const char* JavaVMImpl::singleCall(single_call_function_id_e fn, const Execution
         if (imp_spec)
         {         
             jclass import_spec_wrapper_cls = m_env->FindClass("com/exasol/swig/ImportSpecificationWrapper");
-            check("F-UDF.CL.J-139",calledUndefinedSingleCall);
+            check("F-UDF.CL.SL.JAVA-1021",calledUndefinedSingleCall);
             jmethodID import_spec_wrapper_constructor = m_env->GetMethodID(import_spec_wrapper_cls, "<init>", "(JZ)V");
-            check("F-UDF.CL.J-140",calledUndefinedSingleCall);
+            check("F-UDF.CL.SL.JAVA-1022",calledUndefinedSingleCall);
             args_js = m_env->NewObject(import_spec_wrapper_cls, import_spec_wrapper_constructor, &imp_spec_wrapper, false);
         }
     } else if (fn == SC_FN_GENERATE_SQL_FOR_EXPORT_SPEC) {
@@ -201,9 +201,9 @@ const char* JavaVMImpl::singleCall(single_call_function_id_e fn, const Execution
         if (exp_spec)
         {
             jclass export_spec_wrapper_cls = m_env->FindClass("com/exasol/swig/ExportSpecificationWrapper");
-            check("F-UDF.CL.J-141",calledUndefinedSingleCall);
+            check("F-UDF.CL.SL.JAVA-1023",calledUndefinedSingleCall);
             jmethodID export_spec_wrapper_constructor = m_env->GetMethodID(export_spec_wrapper_cls, "<init>", "(JZ)V");
-            check("F-UDF.CL.J-142",calledUndefinedSingleCall);
+            check("F-UDF.CL.SL.JAVA-1024",calledUndefinedSingleCall);
             args_js = m_env->NewObject(export_spec_wrapper_cls, export_spec_wrapper_constructor, &exp_spec_wrapper, false);
         }
     } else if (fn == SC_FN_VIRTUAL_SCHEMA_ADAPTER_CALL) {
@@ -212,11 +212,11 @@ const char* JavaVMImpl::singleCall(single_call_function_id_e fn, const Execution
         args_js = m_env->NewStringUTF(string_arg.c_str());
     }
     
-    check("F-UDF.CL.J-143",calledUndefinedSingleCall);
+    check("F-UDF.CL.SL.JAVA-1025",calledUndefinedSingleCall);
     jbyteArray resJ = (jbyteArray)m_env->CallStaticObjectMethod(cls, mid, fn_js, args_js);
-    if (check("F-UDF.CL.J-144",calledUndefinedSingleCall) == 0) return strdup("<error during singleCall>");
+    if (check("F-UDF.CL.SL.JAVA-1026",calledUndefinedSingleCall) == 0) return strdup("<error during singleCall>");
     jsize resLen = m_env->GetArrayLength(resJ);
-    check("F-UDF.CL.J-145",calledUndefinedSingleCall);
+    check("F-UDF.CL.SL.JAVA-1027",calledUndefinedSingleCall);
     char* buffer = new char[resLen + 1];
     m_env->GetByteArrayRegion(resJ, 0, resLen, reinterpret_cast<jbyte*>(buffer));
     buffer[resLen] = '\0';
@@ -259,7 +259,7 @@ void JavaVMImpl::createJvm() {
     DBG_FUNC_CALL(cerr,int rc = JNI_CreateJavaVM(&m_jvm, (void**)&m_env, &vm_args));
     if (rc != JNI_OK) {
         stringstream ss;
-        ss << "F-UDF.CL.J-16: Cannot start the JVM: ";
+        ss << "F-UDF.CL.SL.JAVA-1028: Cannot start the JVM: ";
         switch (rc) {
             case JNI_ERR: ss << "unknown error"; break;
             case JNI_EDETACHED: ss << "thread is detached from VM"; break;
@@ -279,23 +279,23 @@ void JavaVMImpl::createJvm() {
 void JavaVMImpl::compileScript() {
     string calledUndefinedSingleCall;
     jstring classnameStr = m_env->NewStringUTF(SWIGVM_params->script_name);
-    check("F-UDF.CL.J-146",calledUndefinedSingleCall);
+    check("F-UDF.CL.SL.JAVA-1029",calledUndefinedSingleCall);
     jstring codeStr = m_env->NewStringUTF(m_scriptCode.c_str());
-    check("F-UDF.CL.J-147",calledUndefinedSingleCall);
+    check("F-UDF.CL.SL.JAVA-1030",calledUndefinedSingleCall);
     jstring classpathStr = m_env->NewStringUTF(m_localClasspath.c_str());
-    check("F-UDF.CL.J-148",calledUndefinedSingleCall);
+    check("F-UDF.CL.SL.JAVA-1031",calledUndefinedSingleCall);
     if (!classnameStr || !codeStr || !classpathStr)
-        throwException("F-UDF.CL.J-17: NewStringUTF for compile failed");
+        throwException("F-UDF.CL.SL.JAVA-1032: NewStringUTF for compile failed");
     jclass cls = m_env->FindClass("com/exasol/ExaCompiler");
-    check("F-UDF.CL.J-149",calledUndefinedSingleCall);
+    check("F-UDF.CL.SL.JAVA-1033",calledUndefinedSingleCall);
     if (!cls)
-        throwException("F-UDF.CL.J-18: FindClass for ExaCompiler failed");
+        throwException("F-UDF.CL.SL.JAVA-1034: FindClass for ExaCompiler failed");
     jmethodID mid = m_env->GetStaticMethodID(cls, "compile", "(Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V");
-    check("F-UDF.CL.J-150",calledUndefinedSingleCall);
+    check("F-UDF.CL.SL.JAVA-1035",calledUndefinedSingleCall);
     if (!mid)
-        throwException("F-UDF.CL.J-19: GetStaticMethodID for compile failed");
+        throwException("F-UDF.CL.SL.JAVA-1036: GetStaticMethodID for compile failed");
     m_env->CallStaticVoidMethod(cls, mid, classnameStr, codeStr, classpathStr);
-    check("F-UDF.CL.J-151",calledUndefinedSingleCall);
+    check("F-UDF.CL.SL.JAVA-1037",calledUndefinedSingleCall);
 }
 
 void JavaVMImpl::addExternalJarPaths() {
@@ -339,7 +339,7 @@ void JavaVMImpl::getScriptClassName() {
           whitespace, 
           lineEnd, 
           pos, 
-          [&](const char* msg){throwException("F-UDF.CL.J-20: "+std::string(msg));}
+          [&](const char* msg){throwException("F-UDF.CL.SL.JAVA-1038: "+std::string(msg));}
           );
     if (scriptClass != "") {
         m_jvmOptions.push_back("-Dexasol.scriptclass=" + scriptClass);
@@ -363,19 +363,19 @@ void JavaVMImpl::importScripts() {
               whitespace, 
               lineEnd, 
               pos, 
-              [&](const char* msg){throwException("F-UDF.CL.J-21: "+std::string(msg));}
+              [&](const char* msg){throwException("F-UDF.CL.SL.JAVA-1039: "+std::string(msg));}
               );
         if (scriptName == "")
             break;
         if (!meta) {
             meta = new SWIGMetadata();
             if (!meta)
-                throwException("F-UDF.CL.J-22: Failure while importing scripts");
+                throwException("F-UDF.CL.SL.JAVA-1040: Failure while importing scripts");
         }
         const char *scriptCode = meta->moduleContent(scriptName.c_str());
         const char *exception = meta->checkException();
         if (exception)
-            throwException("F-UDF.CL.J-23: "+std::string(exception));
+            throwException("F-UDF.CL.SL.JAVA-1041: "+std::string(exception));
         if (m_importedScriptChecksums.insert(scriptToMd5(scriptCode)).second) {
             // Script has not been imported yet
             // If this imported script contains %import statements 
@@ -394,13 +394,13 @@ bool JavaVMImpl::check(const string& errorCode, string& calledUndefinedSingleCal
 
         jclass undefinedSingleCallExceptionClass = m_env->FindClass("com/exasol/ExaUndefinedSingleCallException");
         if (!undefinedSingleCallExceptionClass) {
-            throwException(errorCode+": F-UDF.CL.J-38: FindClass for com.exasol.ExaUndefinedSingleCallException failed");
+            throwException(errorCode+": F-UDF.CL.SL.JAVA-1042: FindClass for com.exasol.ExaUndefinedSingleCallException failed");
         }
         if (m_env->IsInstanceOf(ex, undefinedSingleCallExceptionClass)) {
             jmethodID undefinedRemoteFn = m_env->GetMethodID(undefinedSingleCallExceptionClass, "getUndefinedRemoteFn", "()Ljava/lang/String;");
-            check("F-UDF.CL.J-152",calledUndefinedSingleCall);
+            check("F-UDF.CL.SL.JAVA-1043",calledUndefinedSingleCall);
             if (!undefinedRemoteFn)
-                throwException(errorCode+": F-UDF.CL.J-24: com.exasol.ExaUndefinedSingleCallException.getUndefinedRemoteFn() could not be found");
+                throwException(errorCode+": F-UDF.CL.SL.JAVA-1044: com.exasol.ExaUndefinedSingleCallException.getUndefinedRemoteFn() could not be found");
             jobject undefinedRemoteFnString = m_env->CallObjectMethod(ex,undefinedRemoteFn);
             if (undefinedRemoteFnString) {
                 jstring fn = static_cast<jstring>(undefinedRemoteFnString);
@@ -412,19 +412,19 @@ bool JavaVMImpl::check(const string& errorCode, string& calledUndefinedSingleCal
                 //swig_undefined_single_call_exception ex(fn_string);
                 //throwException(ex);
             } else {
-               throwException(errorCode+": F-UDF.CL.J-25: Internal error: getUndefinedRemoteFn() returned no result"); 
+               throwException(errorCode+": F-UDF.CL.SL.JAVA-1045: Internal error: getUndefinedRemoteFn() returned no result"); 
             } 
         }
 
         string exceptionMessage = "";
         jclass exClass = m_env->GetObjectClass(ex);
         if (!exClass)
-            throwException(errorCode+": F-UDF.CL.J-26: FindClass for Throwable failed");
+            throwException(errorCode+": F-UDF.CL.SL.JAVA-1046: FindClass for Throwable failed");
         // Throwable.toString()
         jmethodID toString = m_env->GetMethodID(exClass, "toString", "()Ljava/lang/String;");
-        check("F-UDF.CL.J-153",calledUndefinedSingleCall);
+        check("F-UDF.CL.SL.JAVA-1047",calledUndefinedSingleCall);
         if (!toString)
-            throwException(errorCode+": F-UDF.CL.J-27: Throwable.toString() could not be found");
+            throwException(errorCode+": F-UDF.CL.SL.JAVA-1048: Throwable.toString() could not be found");
         jobject object = m_env->CallObjectMethod(ex, toString);
         if (object) {
             jstring message = static_cast<jstring>(object);
@@ -434,30 +434,30 @@ bool JavaVMImpl::check(const string& errorCode, string& calledUndefinedSingleCal
             m_env->ReleaseStringUTFChars(message, utfMessage);
         }
         else {
-            exceptionMessage.append(errorCode+": F-UDF.CL.J-28: Throwable.toString(): result is null");
+            exceptionMessage.append(errorCode+": F-UDF.CL.SL.JAVA-1049: Throwable.toString(): result is null");
         }
 
 //        // Build Stacktrace
 //
 //        // Throwable.getStackTrace()
 //        jmethodID getStackTrace = m_env->GetMethodID(exClass, "getStackTrace", "()[Ljava/lang/StackTraceElement;");
-//        check("F-UDF.CL.J-154",calledUndefinedSingleCall);
+//        check("F-UDF.CL.SL.JAVA-1050",calledUndefinedSingleCall);
 //        if (!getStackTrace)
-//            throwException(errorCode+": F-UDF.CL.J-29: Throwable.getStackTrace() could not be found");
+//            throwException(errorCode+": F-UDF.CL.SL.JAVA-1051: Throwable.getStackTrace() could not be found");
 //        jobjectArray frames = (jobjectArray)m_env->CallObjectMethod(ex, getStackTrace);
 //        if (frames) {
 //            jclass frameClass = m_env->FindClass("java/lang/StackTraceElement");
-//            check("F-UDF.CL.J-155",calledUndefinedSingleCall);
+//            check("F-UDF.CL.SL.JAVA-1052",calledUndefinedSingleCall);
 //            if (!frameClass)
-//                throwException(errorCode+": F-UDF.CL.J-30: FindClass for StackTraceElement failed");
+//                throwException(errorCode+": F-UDF.CL.SL.JAVA-1053: FindClass for StackTraceElement failed");
 //            jmethodID frameToString = m_env->GetMethodID(frameClass, "toString", "()Ljava/lang/String;");
-//            check("F-UDF.CL.J-156",calledUndefinedSingleCall);
+//            check("F-UDF.CL.SL.JAVA-1054",calledUndefinedSingleCall);
 //            if (!frameToString)
-//                throwException(errorCode+": F-UDF.CL.J-31: StackTraceElement.toString() could not be found");
+//                throwException(errorCode+": F-UDF.CL.SL.JAVA-1055: StackTraceElement.toString() could not be found");
 //            jsize framesLength = m_env->GetArrayLength(frames);
 //            for (int i = 0; i < framesLength; i++) {
 //                jobject frame = m_env->GetObjectArrayElement(frames, i);
-//                check("F-UDF.CL.J-157",calledUndefinedSingleCall);
+//                check("F-UDF.CL.SL.JAVA-1056",calledUndefinedSingleCall);
 //                jobject frameMsgObj = m_env->CallObjectMethod(frame, frameToString);
 //                if (frameMsgObj) {
 //                    jstring message = static_cast<jstring>(frameMsgObj);
@@ -488,13 +488,13 @@ bool JavaVMImpl::check(const string& errorCode, string& calledUndefinedSingleCal
 void JavaVMImpl::registerFunctions() {
     string calledUndefinedSingleCall;
     jclass cls = m_env->FindClass("com/exasol/swig/exascript_javaJNI");
-    check("F-UDF.CL.J-158",calledUndefinedSingleCall);
+    check("F-UDF.CL.SL.JAVA-1057",calledUndefinedSingleCall);
     if (!cls)
-        throwException("F-UDF.CL.J-32: FindClass for exascript_javaJNI failed");
+        throwException("F-UDF.CL.SL.JAVA-1058: FindClass for exascript_javaJNI failed");
     int rc = m_env->RegisterNatives(cls, methods, sizeof(methods) / sizeof(methods[0]));
-    check("F-UDF.CL.J-159",calledUndefinedSingleCall);
+    check("F-UDF.CL.SL.JAVA-1059",calledUndefinedSingleCall);
     if (rc)
-        throwException("F-UDF.CL.J-33: RegisterNatives failed");
+        throwException("F-UDF.CL.SL.JAVA-1060: RegisterNatives failed");
 }
 
 void JavaVMImpl::setClasspath() {
@@ -522,19 +522,19 @@ void JavaVMImpl::addJarToClasspath(const string& path) {
         rc = stat(jarPath.c_str(), &st);
         if (rc) {
             stringstream errorMsg;
-            errorMsg << "F-UDF.CL.J-34: Java VM cannot find '" << jarPath.c_str() << "': " << strerror(errno);
+            errorMsg << "F-UDF.CL.SL.JAVA-1061: Java VM cannot find '" << jarPath.c_str() << "': " << strerror(errno);
             throwException(errorMsg.str().c_str());
         }
     }
     else if (rc) {
         stringstream errorMsg;
-        errorMsg << "F-UDF.CL.J-35: Java VM cannot find '" << jarPath.c_str() << "': " << strerror(errno);
+        errorMsg << "F-UDF.CL.SL.JAVA-1062: Java VM cannot find '" << jarPath.c_str() << "': " << strerror(errno);
         throwException(errorMsg.str().c_str());
     }
 
     if (!S_ISREG(st.st_mode)) {
         stringstream errorMsg;
-        errorMsg << "F-UDF.CL.J-36: '" << jarPath.c_str() << "' is not a regular file";
+        errorMsg << "F-UDF.CL.SL.JAVA-1063: '" << jarPath.c_str() << "' is not a regular file";
         throwException(errorMsg.str().c_str());
     }
 
@@ -555,7 +555,7 @@ void JavaVMImpl::getExternalJvmOptions() {
               whitespace, 
               lineEnd, 
               pos, 
-              [&](const char* msg){throwException("F-UDF.CL.J-37: "+std::string(msg));}
+              [&](const char* msg){throwException("F-UDF.CL.SL.JAVA-1064: "+std::string(msg));}
               );
         if (options == "")
             break;

--- a/exaudfclient/base/python/exascript_python_preset_core.py
+++ b/exaudfclient/base/python/exascript_python_preset_core.py
@@ -88,7 +88,7 @@ class exa:
         code = self.__meta.moduleContent(encodeUTF8(modname))
         msg = self.__meta.checkException()
 
-        if msg: raise ImportError(u"Importing module %s failed: %s" % (modname, msg))
+        if msg: raise ImportError(u"F-UDF.CL.PY-34: Importing module %s failed: %s" % (modname, msg))
         code = decodeUTF8(code)
         if str(code) in self.__modules:
             print("%%% found code", modname, repr(code))
@@ -105,7 +105,7 @@ class exa:
                 else:
                     exec(compile(code, script, 'exec')) in modobj.__dict__
             except Exception as err:
-                raise ImportError(u"Importing module %s failed: %s" % (modname, str(err)))
+                raise ImportError(u"F-UDF.CL.PY-35: Importing module %s failed: %s" % (modname, str(err)))
         return modobj
 
 
@@ -124,7 +124,7 @@ class exa:
         connection_name = unicode(name)
         connectionInfo = self.__meta.connectionInformation(encodeUTF8(connection_name))
         msg = self.__meta.checkException()
-        if msg: raise ImportError(u"get_connection for connection name %s failed: %s" % (name, msg))
+        if msg: raise ImportError(u"F-UDF.CL.PY-36: get_connection for connection name %s failed: %s" % (name, msg))
         return exa.ConnectionInformation(decodeUTF8(connectionInfo.copyKind()), decodeUTF8(connectionInfo.copyAddress()), decodeUTF8(connectionInfo.copyUser()), decodeUTF8(connectionInfo.copyPassword()))
 
 
@@ -148,7 +148,8 @@ def __pythonvm_wrapped_parse(env):
         else:
             exec(compile(exa.meta.script_code, exa.meta.script_name, 'exec')) in globals()
     except Exception as err:
-        errtypel, errobj, backtrace = sys.exc_info()
-        if backtrace.tb_next: backtrace = backtrace.tb_next
-        err.args = ("".join(traceback.format_exception(errtypel, errobj, backtrace)),)
+        import traceback
+        backtrace = traceback.format_exc()
+        print("F-UDF.CL.PY-37: Caught exception:\n"+backtrace)
+        err.args = ("F-UDF.CL.PY-38: Caught exception:\n"+backtrace,)
         raise err

--- a/exaudfclient/base/python/exascript_python_preset_core.py
+++ b/exaudfclient/base/python/exascript_python_preset_core.py
@@ -108,7 +108,7 @@ class exa:
         code = self.__meta.moduleContent(encodeUTF8(modname))
         msg = self.__meta.checkException()
 
-        if msg: raise ImportError(u"F-UDF.CL.PY-34: Importing module %s failed: %s" % (modname, msg))
+        if msg: raise ImportError(u"F-UDF.CL.SL.PYTHON-1119: Importing module %s failed: %s" % (modname, msg))
         code = decodeUTF8(code)
         if str(code) in self.__modules:
             print("%%% found code", modname, repr(code))
@@ -126,7 +126,7 @@ class exa:
                     exec(compile(code, script, 'exec')) in modobj.__dict__
             except BaseException as err:
                 raise create_exception_with_complete_backtrace(
-                        "F-UDF.CL.PY-35",
+                        "F-UDF.CL.SL.PYTHON-1120",
                         "Importing module %s failed"%modname,
                         sys.exc_info())
         return modobj
@@ -147,7 +147,7 @@ class exa:
         connection_name = unicode(name)
         connectionInfo = self.__meta.connectionInformation(encodeUTF8(connection_name))
         msg = self.__meta.checkException()
-        if msg: raise ImportError(u"F-UDF.CL.PY-36: get_connection for connection name %s failed: %s" % (name, msg))
+        if msg: raise ImportError(u"F-UDF.CL.SL.PYTHON-1121: get_connection for connection name %s failed: %s" % (name, msg))
         return exa.ConnectionInformation(decodeUTF8(connectionInfo.copyKind()), decodeUTF8(connectionInfo.copyAddress()), decodeUTF8(connectionInfo.copyUser()), decodeUTF8(connectionInfo.copyPassword()))
 
 
@@ -172,6 +172,6 @@ def __pythonvm_wrapped_parse(env):
             exec(compile(exa.meta.script_code, exa.meta.script_name, 'exec')) in globals()
     except BaseException as err:
         raise create_exception_with_complete_backtrace(
-                "F-UDF.CL.PY-38",
+                "F-UDF.CL.SL.PYTHON-1122",
                 "Exception while parsing UDF",
                 sys.exc_info())

--- a/exaudfclient/base/python/exascript_python_preset_core.py
+++ b/exaudfclient/base/python/exascript_python_preset_core.py
@@ -104,8 +104,10 @@ class exa:
                     exec(compile(code, script, 'exec'), modobj.__dict__)
                 else:
                     exec(compile(code, script, 'exec')) in modobj.__dict__
-            except Exception as err:
-                raise ImportError(u"F-UDF.CL.PY-35: Importing module %s failed: %s" % (modname, str(err)))
+            except BaseException as err:
+                import traceback
+                backtrace = traceback.format_exc()
+                raise ImportError(u"F-UDF.CL.PY-35: Importing module %s failed with\n%s" % (modname, backtrace))
         return modobj
 
 
@@ -147,9 +149,9 @@ def __pythonvm_wrapped_parse(env):
             exec(compile(exa.meta.script_code, exa.meta.script_name, 'exec'), env)
         else:
             exec(compile(exa.meta.script_code, exa.meta.script_name, 'exec')) in globals()
-    except Exception as err:
+    except BaseException as err:
         import traceback
         backtrace = traceback.format_exc()
-        print("F-UDF.CL.PY-37: Caught exception:\n"+backtrace)
-        err.args = ("F-UDF.CL.PY-38: Caught exception:\n"+backtrace,)
+        print("F-UDF.CL.PY-37: Caught exception while parsing the UDF code:\n"+backtrace)
+        err.args = ("F-UDF.CL.PY-38: Caught exception while parsing the UDF code:\n"+backtrace,)
         raise err

--- a/exaudfclient/base/python/exascript_python_wrap.py
+++ b/exaudfclient/base/python/exascript_python_wrap.py
@@ -88,26 +88,26 @@ class exaiter(object):
         self.__data = data
     def __getitem__(self, key):
         if self.__finished:
-            raise RuntimeError("Iteration finished")
+            raise RuntimeError("E-UDF.CL.PY-1: Iteration finished")
         if key not in self.__data:
             key = unicode(key)
             if key not in self.__data:
-                raise RuntimeError(u"Column with name '%s' does not exist" % key)
+                raise RuntimeError(u"E-UDF.CL.PY-2: Column with name '%s' does not exist" % key)
         ret, null = self.__data[key]()
         msg = self.__inp.checkException()
-        if msg: raise RuntimeError(msg)
+        if msg: raise RuntimeError("F-UDF.CL.PY-5: "+msg)
         if null: return None
         return ret
     def __getattr__(self, key):
         if self.__finished:
-            raise RuntimeError("Iteration finished")
+            raise RuntimeError("E-UDF.CL.PY-3: Iteration finished")
         if key not in self.__data:
             key = unicode(key)
             if key not in self.__data:
-                raise RuntimeError(u"Iterator has no object with name '%s'" % key)
+                raise RuntimeError(u"E-UDF.CL.PY-4: Iterator has no object with name '%s'" % key)
         ret, null = self.__data[key]()
         msg = self.__inp.checkException()
-        if msg: raise RuntimeError(msg)
+        if msg: raise RuntimeError("F-UDF.CL.PY-6: "+msg)
         if null: return None
         return ret
     def emit(self, *output):
@@ -125,16 +125,16 @@ class exaiter(object):
             import pandas as pd
             v = output[0]
             if v.shape[0] == 0:
-                raise RuntimeError("emit DataFrame is empty")
+                raise RuntimeError("E-UDF.CL.PY-7: emit DataFrame is empty")
             if v.shape[1] != len(self.__outcoltypes):
                 exp_num_out = len(self.__outcoltypes)
-                raise TypeError("emit() takes exactly %d argument%s (%d given)" % (exp_num_out, 's' if exp_num_out > 1 else '', v.shape[1]))
+                raise TypeError("E-UDF.CL.PY-8: emit() takes exactly %d argument%s (%d given)" % (exp_num_out, 's' if exp_num_out > 1 else '', v.shape[1]))
             pyextdataframe.emit_dataframe(self, v)
             return
         if len(output) != len(self.__outcoltypes):
             if len(self.__outcoltypes) > 1:
-                raise TypeError("emit() takes exactly %d arguments (%d given)" % (len(self.__outcoltypes), len(output)))
-            else: raise TypeError("emit() takes exactly %d argument (%d given)" % (len(self.__outcoltypes), len(output)))
+                raise TypeError("E-UDF.CL.PY-9: emit() takes exactly %d arguments (%d given)" % (len(self.__outcoltypes), len(output)))
+            else: raise TypeError("E-UDF.CL.PY-10: emit() takes exactly %d argument (%d given)" % (len(self.__outcoltypes), len(output)))
         for v in output:
             if v == None: self.__out.setNull(k)
             elif type(v) in (int, long):
@@ -143,7 +143,7 @@ class exaiter(object):
                 elif self.__outcoltypes[k] == NUMERIC: self.__out.setNumeric(k, str(int(v)))
                 elif self.__outcoltypes[k] == DOUBLE: self.__out.setDouble(k, float(v))
                 else:
-                    raise RuntimeError(u"emit column '%s' is of type %s but data given have type %s" \
+                    raise RuntimeError(u"E-UDF.CL.PY-11: emit column '%s' is of type %s but data given have type %s" \
                             % (decodeUTF8(self.__meta.outputColumnName(k)), type_names.get(self.__outcoltypes[k], 'UNKONWN'), str(type(v))))
             elif type(v) == float:
                 if self.__outcoltypes[k] == DOUBLE: self.__out.setDouble(k, float(v))
@@ -151,11 +151,11 @@ class exaiter(object):
                 elif self.__outcoltypes[k] == INT64: self.__out.setInt64(k, int(v))
                 elif self.__outcoltypes[k] == NUMERIC: self.__out.setInt64(k, str(v))
                 else:
-                    raise RuntimeError(u"emit column '%s' is of type %s but data given have type %s" \
+                    raise RuntimeError(u"E-UDF.CL.PY-12: emit column '%s' is of type %s but data given have type %s" \
                             % (decodeUTF8(self.__meta.outputColumnName(k)), type_names.get(self.__outcoltypes[k], 'UNKONWN'), str(type(v))))
             elif type(v) == bool:
                 if self.__outcoltypes[k] != BOOLEAN:
-                    raise RuntimeError(u"emit column '%s' is of type %s but data given have type %s" \
+                    raise RuntimeError(u"E-UDF.CL.PY-13: emit column '%s' is of type %s but data given have type %s" \
                             % (decodeUTF8(self.__meta.outputColumnName(k)), type_names.get(self.__outcoltypes[k], 'UNKONWN'), str(type(v))))
                 self.__out.setBoolean(k, bool(v))
             elif type(v) in (str, unicode):
@@ -165,7 +165,7 @@ class exaiter(object):
                 v = encodeUTF8(v)
                 vl = len(v)
                 if self.__outcoltypes[k] != STRING:
-                    raise RuntimeError(u"emit column '%s' is of type %s but data given have type %s" \
+                    raise RuntimeError(u"E-UDF.CL.PY-14: emit column '%s' is of type %s but data given have type %s" \
                             % (decodeUTF8(self.__meta.outputColumnName(k)), type_names.get(self.__outcoltypes[k], 'UNKONWN'), str(type(v))))
                 self.__out.setString(k, v, vl)
             elif type(v) == decimal.Decimal:
@@ -174,26 +174,26 @@ class exaiter(object):
                 elif self.__outcoltypes[k] == INT64: self.__out.setInt64(k, int(v))
                 elif self.__outcoltypes[k] == DOUBLE: self.__out.setDouble(k, float(v))
                 else:
-                    raise RuntimeError("emit column '%s' is of type %s but data given have type %s" \
+                    raise RuntimeError("E-UDF.CL.PY-15: emit column '%s' is of type %s but data given have type %s" \
                             % (decodeUTF8(self.__meta.outputColumnName(k)), type_names.get(self.__outcoltypes[k], 'UNKONWN'), str(type(v))))
             elif type(v) == datetime.date:
                 if self.__outcoltypes[k] != DATE:
-                    raise RuntimeError("emit column '%s' is of type %s but data given have type %s" \
+                    raise RuntimeError("E-UDF.CL.PY-16: emit column '%s' is of type %s but data given have type %s" \
                             % (decodeUTF8(self.__meta.outputColumnName(k)), type_names.get(self.__outcoltypes[k], 'UNKONWN'), str(type(v))))
                 self.__out.setDate(k, v.isoformat())
             elif type(v) == datetime.datetime:
                 if self.__outcoltypes[k] != TIMESTAMP:
-                    raise RuntimeError("emit column '%s' is of type %s but data given have type %s" \
+                    raise RuntimeError("E-UDF.CL.PY-17: emit column '%s' is of type %s but data given have type %s" \
                             % (decodeUTF8(self.__meta.outputColumnName(k)), type_names.get(self.__outcoltypes[k], 'UNKONWN'), str(type(v))))
                 self.__out.setTimestamp(k, v.isoformat(' '))
-            else: raise RuntimeError("data type %s is not supported" % str(type(v)))
+            else: raise RuntimeError("E-UDF.CL.PY-18: data type %s is not supported" % str(type(v)))
             msg = self.__out.checkException()
-            if msg: raise RuntimeError(msg)
+            if msg: raise RuntimeError("F-UDF.CL.PY-19: "+msg)
             k += 1
         ret = self.__out.next()
         msg = self.__out.checkException()
-        if msg: raise RuntimeError(msg)
-        if ret != True: raise RuntimeError("Internal error on emiting row")
+        if msg: raise RuntimeError("F-UDF.CL.PY-20: "+msg)
+        if ret != True: raise RuntimeError("F-UDF.CL.PY-21: Internal error on emiting row")
     def next(self, reset = False):
         self.__cache = [None] * len(self.__cache)
         if reset:
@@ -203,23 +203,23 @@ class exaiter(object):
         elif self.__finished: return False
         else: val = self.__inp.next()
         msg = self.__inp.checkException()
-        if msg: raise RuntimeError(msg)
+        if msg: raise RuntimeError("F-UDF.CL.PY-22: "+msg)
         if not val:
             self.__finished = True
         return val
     def get_dataframe(self, num_rows=1, start_col=0):
         import pandas
         if not (num_rows == "all" or (type(num_rows) in (int, long) and num_rows > 0)):
-            raise RuntimeError("get_dataframe() parameter 'num_rows' must be 'all' or an integer > 0")
+            raise RuntimeError("E-UDF.CL.PY-23: get_dataframe() parameter 'num_rows' must be 'all' or an integer > 0")
         if (type(start_col) not in (int, long) or start_col < 0):
-            raise RuntimeError("get_dataframe() parameter 'start_col' must be an integer >= 0")
+            raise RuntimeError("E-UDF.CL.PY-24: get_dataframe() parameter 'start_col' must be an integer >= 0")
         if (start_col > len(self.__incolnames)):
-            raise RuntimeError("get_dataframe() parameter 'start_col' is %d, but there are only %d input columns" % (start_col, len(self.__incolnames)))
+            raise RuntimeError("E-UDF.CL.PY-25: get_dataframe() parameter 'start_col' is %d, but there are only %d input columns" % (start_col, len(self.__incolnames)))
         if num_rows == "all":
             num_rows = sys.maxsize
         if self.__dataframe_finished:
             # Exception after None already returned
-            raise RuntimeError("Iteration finished")
+            raise RuntimeError("E-UDF.CL.PY-26: Iteration finished")
         elif self.__finished:
             # Return None the first time there is no data
             self.__dataframe_finished = True
@@ -234,18 +234,31 @@ class exaiter(object):
         return self.__inp.rowsInGroup()
 
 def __disallowed_function(*args, **kw):
-    raise RuntimeError("next(), reset() and emit() functions are not allowed in scalar context")
+    raise RuntimeError("F-UDF.CL.PY-116: next(), reset() and emit() functions are not allowed in scalar context")
+
+def __pythonvm_wrapped_cleanup():
+    cleanupfunc = None
+    try: cleanupfunc = globals()['cleanup']
+    except: raise RuntimeError("F-UDF.CL.PY-117: function 'cleanup' is not defined")
+    try:
+        cleanupfunc()
+    except Exception as err:
+        import traceback
+        backtrace = traceback.format_exc()
+        print("F-UDF.CL.PY-118: Caught exception:\n"+backtrace)
+        err.args = ("F-UDF.CL.PY-119: Caught exception:\n"+backtrace,)
+        raise err
 
 def __pythonvm_wrapped_run():
     runfunc = None
     try: runfunc = globals()['run']
-    except: raise RuntimeError("function 'run' is not defined")
+    except: raise RuntimeError("F-UDF.CL.PY-27: function 'run' is not defined")
     inp = TableIterator(); msg = inp.checkException();
-    if msg: raise RuntimeError(msg)
+    if msg: raise RuntimeError("F-UDF.CL.PY-28: "+msg)
     out = ResultHandler(inp); msg = out.checkException();
-    if msg: raise RuntimeError(msg)
+    if msg: raise RuntimeError("F-UDF.CL.PY-29: "+msg)
     meta = Metadata(); msg = meta.checkException();
-    if msg: raise RuntimeError(msg)
+    if msg: raise RuntimeError("F-UDF.CL.PY-30: "+msg)
     try:
         iter = exaiter(meta, inp, out); iter_next = iter.next; iter_emit = iter.emit
         if meta.outputType() == EXACTLY_ONCE:
@@ -266,9 +279,10 @@ def __pythonvm_wrapped_run():
                     if not iter_next(): break
         out.flush()
     except Exception as err:
-        errtypel, errobj, backtrace = sys.exc_info()
-        if backtrace.tb_next: backtrace = backtrace.tb_next
-        err.args = ("".join(traceback.format_exception(errtypel, errobj, backtrace)),)
+        import traceback
+        backtrace = traceback.format_exc()
+        print("F-UDF.CL.PY-31: Caught exception:\n"+backtrace)
+        err.args = ("F-UDF.CL.PY-32: Caught exception:\n"+backtrace,)
         raise err
 
 
@@ -325,6 +339,6 @@ def __pythonvm_wrapped_singleCall(fn,arg=None):
                 exp_spec._setConnectionInformation(__ConnectionInformation(exp_spec.connection))
             return fn(exp_spec)
         else:
-            raise RuntimeError("Unknown single call function: "+str(fn))
+            raise RuntimeError("F-UDF.CL.PY-33: Unknown single call function: "+str(fn))
     else:
         return fn()

--- a/exaudfclient/base/python/exascript_python_wrap.py
+++ b/exaudfclient/base/python/exascript_python_wrap.py
@@ -243,11 +243,10 @@ def __pythonvm_wrapped_cleanup():
     try:
         cleanupfunc()
     except BaseException as err:
-        import traceback
-        backtrace = traceback.format_exc()
-        print("F-UDF.CL.PY-118: Caught exception while executing cleanup:\n"+backtrace)
-        err.args = ("F-UDF.CL.PY-119: Caught exception while executing cleanup:\n"+backtrace,)
-        raise err
+        raise create_exception_with_complete_backtrace(
+                "F-UDF.CL.PY-119",
+                "Exception during cleanup",
+                sys.exc_info())
 
 def __pythonvm_wrapped_run():
     runfunc = None
@@ -279,12 +278,10 @@ def __pythonvm_wrapped_run():
                     if not iter_next(): break
         out.flush()
     except BaseException as err:
-        import traceback
-        backtrace = traceback.format_exc()
-        print("F-UDF.CL.PY-31: Caught exception while executing run:\n"+backtrace)
-        err.args = ("F-UDF.CL.PY-32: Caught exception while executing run:\n"+backtrace,)
-        raise err
-
+        raise create_exception_with_complete_backtrace(
+                "F-UDF.CL.PY-32",
+                "Exception during run",
+                sys.exc_info())
 
 
 class __ImportSpecification:
@@ -335,11 +332,10 @@ def __pythonvm_wrapped_singleCall(fn,arg=None):
             try:
                 return fn(imp_spec)
             except BaseException as err:
-                import traceback
-                backtrace = traceback.format_exc()
-                print("F-UDF.CL.PY-121: Caught exception while executing singleCall %s:\n%s"%(fn.__name__,backtrace))
-                err.args = ("F-UDF.CL.PY-115: Caught exception while executing singleCall %s:\n%s"%(fn.__name__,backtrace),)
-                raise err
+                raise create_exception_with_complete_backtrace(
+                        "F-UDF.CL.PY-115",
+                        "Exception during singleCall %s"%fn.__name__,
+                        sys.exc_info())
         elif "generate_sql_for_export_spec" in globals() and fn == generate_sql_for_export_spec:
             exp_spec = __ExportSpecification(arg)
             if exp_spec.connection:
@@ -347,19 +343,18 @@ def __pythonvm_wrapped_singleCall(fn,arg=None):
             try:
                 return fn(exp_spec)
             except BaseException as err:
-                import traceback
-                backtrace = traceback.format_exc()
-                print("F-UDF.CL.PY-124: Caught exception while executing singleCall %s:\n%s"%(fn.__name__,backtrace))
-                err.args = ("F-UDF.CL.PY-125: Caught exception while executing singleCall %s:\n%s"%(fn.__name__,backtrace),)
-                raise err
+                raise create_exception_with_complete_backtrace(
+                        "F-UDF.CL.PY-125",
+                        "Exception during singleCall %s"%fn.__name__,
+                        sys.exc_info())
         else:
             raise RuntimeError("F-UDF.CL.PY-33: Unknown single call function: "+str(fn))
     else:
         try:
             return fn()
         except BaseException as err:
-            import traceback
-            backtrace = traceback.format_exc()
-            print("F-UDF.CL.PY-126: Caught exception while executing singleCall %s:\n%s"%(fn.__name__,backtrace))
-            err.args = ("F-UDF.CL.PY-127: Caught exception while executing singleCall %s:\n%s"%(fn.__name__,backtrace),)
-            raise err
+            raise create_exception_with_complete_backtrace(
+                    "F-UDF.CL.PY-127",
+                    "Exception during singleCall %s"%fn.__name__,
+                    sys.exc_info())
+

--- a/exaudfclient/base/python/exascript_python_wrap.py
+++ b/exaudfclient/base/python/exascript_python_wrap.py
@@ -242,11 +242,11 @@ def __pythonvm_wrapped_cleanup():
     except: raise RuntimeError("F-UDF.CL.PY-117: function 'cleanup' is not defined")
     try:
         cleanupfunc()
-    except Exception as err:
+    except BaseException as err:
         import traceback
         backtrace = traceback.format_exc()
-        print("F-UDF.CL.PY-118: Caught exception:\n"+backtrace)
-        err.args = ("F-UDF.CL.PY-119: Caught exception:\n"+backtrace,)
+        print("F-UDF.CL.PY-118: Caught exception while executing cleanup:\n"+backtrace)
+        err.args = ("F-UDF.CL.PY-119: Caught exception while executing cleanup:\n"+backtrace,)
         raise err
 
 def __pythonvm_wrapped_run():
@@ -278,11 +278,11 @@ def __pythonvm_wrapped_run():
                     runfunc(iter)
                     if not iter_next(): break
         out.flush()
-    except Exception as err:
+    except BaseException as err:
         import traceback
         backtrace = traceback.format_exc()
-        print("F-UDF.CL.PY-31: Caught exception:\n"+backtrace)
-        err.args = ("F-UDF.CL.PY-32: Caught exception:\n"+backtrace,)
+        print("F-UDF.CL.PY-31: Caught exception while executing run:\n"+backtrace)
+        err.args = ("F-UDF.CL.PY-32: Caught exception while executing run:\n"+backtrace,)
         raise err
 
 

--- a/exaudfclient/base/python/exascript_python_wrap.py
+++ b/exaudfclient/base/python/exascript_python_wrap.py
@@ -332,13 +332,34 @@ def __pythonvm_wrapped_singleCall(fn,arg=None):
             imp_spec = __ImportSpecification(arg)
             if imp_spec.connection:
                 imp_spec._setConnectionInformation(__ConnectionInformation(imp_spec.connection))
-            return fn(imp_spec)
+            try:
+                return fn(imp_spec)
+            except BaseException as err:
+                import traceback
+                backtrace = traceback.format_exc()
+                print("F-UDF.CL.PY-31: Caught exception while executing singleCall %s:\n%s"%(fn.__name__,backtrace))
+                err.args = ("F-UDF.CL.PY-32: Caught exception while executing singleCall %s:\n%s"%(fn.__name__,backtrace),)
+                raise err
         elif "generate_sql_for_export_spec" in globals() and fn == generate_sql_for_export_spec:
             exp_spec = __ExportSpecification(arg)
             if exp_spec.connection:
                 exp_spec._setConnectionInformation(__ConnectionInformation(exp_spec.connection))
-            return fn(exp_spec)
+            try:
+                return fn(exp_spec)
+            except BaseException as err:
+                import traceback
+                backtrace = traceback.format_exc()
+                print("F-UDF.CL.PY-31: Caught exception while executing singleCall %s:\n%s"%(fn.__name__,backtrace))
+                err.args = ("F-UDF.CL.PY-32: Caught exception while executing singleCall %s:\n%s"%(fn.__name__,backtrace),)
+                raise err
         else:
             raise RuntimeError("F-UDF.CL.PY-33: Unknown single call function: "+str(fn))
     else:
-        return fn()
+        try:
+            return fn()
+        except BaseException as err:
+            import traceback
+            backtrace = traceback.format_exc()
+            print("F-UDF.CL.PY-31: Caught exception while executing singleCall %s:\n%s"%(fn.__name__,backtrace))
+            err.args = ("F-UDF.CL.PY-32: Caught exception while executing singleCall %s:\n%s"%(fn.__name__,backtrace),)
+            raise err

--- a/exaudfclient/base/python/exascript_python_wrap.py
+++ b/exaudfclient/base/python/exascript_python_wrap.py
@@ -88,26 +88,26 @@ class exaiter(object):
         self.__data = data
     def __getitem__(self, key):
         if self.__finished:
-            raise RuntimeError("E-UDF.CL.PY-1: Iteration finished")
+            raise RuntimeError("E-UDF.CL.SL.PYTHON-1081: Iteration finished")
         if key not in self.__data:
             key = unicode(key)
             if key not in self.__data:
-                raise RuntimeError(u"E-UDF.CL.PY-2: Column with name '%s' does not exist" % key)
+                raise RuntimeError(u"E-UDF.CL.SL.PYTHON-1082: Column with name '%s' does not exist" % key)
         ret, null = self.__data[key]()
         msg = self.__inp.checkException()
-        if msg: raise RuntimeError("F-UDF.CL.PY-5: "+msg)
+        if msg: raise RuntimeError("F-UDF.CL.SL.PYTHON-1083: "+msg)
         if null: return None
         return ret
     def __getattr__(self, key):
         if self.__finished:
-            raise RuntimeError("E-UDF.CL.PY-3: Iteration finished")
+            raise RuntimeError("E-UDF.CL.SL.PYTHON-1084: Iteration finished")
         if key not in self.__data:
             key = unicode(key)
             if key not in self.__data:
-                raise RuntimeError(u"E-UDF.CL.PY-4: Iterator has no object with name '%s'" % key)
+                raise RuntimeError(u"E-UDF.CL.SL.PYTHON-1085: Iterator has no object with name '%s'" % key)
         ret, null = self.__data[key]()
         msg = self.__inp.checkException()
-        if msg: raise RuntimeError("F-UDF.CL.PY-6: "+msg)
+        if msg: raise RuntimeError("F-UDF.CL.SL.PYTHON-1086: "+msg)
         if null: return None
         return ret
     def emit(self, *output):
@@ -125,16 +125,16 @@ class exaiter(object):
             import pandas as pd
             v = output[0]
             if v.shape[0] == 0:
-                raise RuntimeError("E-UDF.CL.PY-7: emit DataFrame is empty")
+                raise RuntimeError("E-UDF.CL.SL.PYTHON-1087: emit DataFrame is empty")
             if v.shape[1] != len(self.__outcoltypes):
                 exp_num_out = len(self.__outcoltypes)
-                raise TypeError("E-UDF.CL.PY-8: emit() takes exactly %d argument%s (%d given)" % (exp_num_out, 's' if exp_num_out > 1 else '', v.shape[1]))
+                raise TypeError("E-UDF.CL.SL.PYTHON-1088: emit() takes exactly %d argument%s (%d given)" % (exp_num_out, 's' if exp_num_out > 1 else '', v.shape[1]))
             pyextdataframe.emit_dataframe(self, v)
             return
         if len(output) != len(self.__outcoltypes):
             if len(self.__outcoltypes) > 1:
-                raise TypeError("E-UDF.CL.PY-9: emit() takes exactly %d arguments (%d given)" % (len(self.__outcoltypes), len(output)))
-            else: raise TypeError("E-UDF.CL.PY-10: emit() takes exactly %d argument (%d given)" % (len(self.__outcoltypes), len(output)))
+                raise TypeError("E-UDF.CL.SL.PYTHON-1089: emit() takes exactly %d arguments (%d given)" % (len(self.__outcoltypes), len(output)))
+            else: raise TypeError("E-UDF.CL.SL.PYTHON-1090: emit() takes exactly %d argument (%d given)" % (len(self.__outcoltypes), len(output)))
         for v in output:
             if v == None: self.__out.setNull(k)
             elif type(v) in (int, long):
@@ -143,7 +143,7 @@ class exaiter(object):
                 elif self.__outcoltypes[k] == NUMERIC: self.__out.setNumeric(k, str(int(v)))
                 elif self.__outcoltypes[k] == DOUBLE: self.__out.setDouble(k, float(v))
                 else:
-                    raise RuntimeError(u"E-UDF.CL.PY-11: emit column '%s' is of type %s but data given have type %s" \
+                    raise RuntimeError(u"E-UDF.CL.SL.PYTHON-1091: emit column '%s' is of type %s but data given have type %s" \
                             % (decodeUTF8(self.__meta.outputColumnName(k)), type_names.get(self.__outcoltypes[k], 'UNKONWN'), str(type(v))))
             elif type(v) == float:
                 if self.__outcoltypes[k] == DOUBLE: self.__out.setDouble(k, float(v))
@@ -151,11 +151,11 @@ class exaiter(object):
                 elif self.__outcoltypes[k] == INT64: self.__out.setInt64(k, int(v))
                 elif self.__outcoltypes[k] == NUMERIC: self.__out.setInt64(k, str(v))
                 else:
-                    raise RuntimeError(u"E-UDF.CL.PY-12: emit column '%s' is of type %s but data given have type %s" \
+                    raise RuntimeError(u"E-UDF.CL.SL.PYTHON-1092: emit column '%s' is of type %s but data given have type %s" \
                             % (decodeUTF8(self.__meta.outputColumnName(k)), type_names.get(self.__outcoltypes[k], 'UNKONWN'), str(type(v))))
             elif type(v) == bool:
                 if self.__outcoltypes[k] != BOOLEAN:
-                    raise RuntimeError(u"E-UDF.CL.PY-13: emit column '%s' is of type %s but data given have type %s" \
+                    raise RuntimeError(u"E-UDF.CL.SL.PYTHON-1093: emit column '%s' is of type %s but data given have type %s" \
                             % (decodeUTF8(self.__meta.outputColumnName(k)), type_names.get(self.__outcoltypes[k], 'UNKONWN'), str(type(v))))
                 self.__out.setBoolean(k, bool(v))
             elif type(v) in (str, unicode):
@@ -165,7 +165,7 @@ class exaiter(object):
                 v = encodeUTF8(v)
                 vl = len(v)
                 if self.__outcoltypes[k] != STRING:
-                    raise RuntimeError(u"E-UDF.CL.PY-14: emit column '%s' is of type %s but data given have type %s" \
+                    raise RuntimeError(u"E-UDF.CL.SL.PYTHON-1094: emit column '%s' is of type %s but data given have type %s" \
                             % (decodeUTF8(self.__meta.outputColumnName(k)), type_names.get(self.__outcoltypes[k], 'UNKONWN'), str(type(v))))
                 self.__out.setString(k, v, vl)
             elif type(v) == decimal.Decimal:
@@ -174,26 +174,26 @@ class exaiter(object):
                 elif self.__outcoltypes[k] == INT64: self.__out.setInt64(k, int(v))
                 elif self.__outcoltypes[k] == DOUBLE: self.__out.setDouble(k, float(v))
                 else:
-                    raise RuntimeError("E-UDF.CL.PY-15: emit column '%s' is of type %s but data given have type %s" \
+                    raise RuntimeError("E-UDF.CL.SL.PYTHON-1095: emit column '%s' is of type %s but data given have type %s" \
                             % (decodeUTF8(self.__meta.outputColumnName(k)), type_names.get(self.__outcoltypes[k], 'UNKONWN'), str(type(v))))
             elif type(v) == datetime.date:
                 if self.__outcoltypes[k] != DATE:
-                    raise RuntimeError("E-UDF.CL.PY-16: emit column '%s' is of type %s but data given have type %s" \
+                    raise RuntimeError("E-UDF.CL.SL.PYTHON-1096: emit column '%s' is of type %s but data given have type %s" \
                             % (decodeUTF8(self.__meta.outputColumnName(k)), type_names.get(self.__outcoltypes[k], 'UNKONWN'), str(type(v))))
                 self.__out.setDate(k, v.isoformat())
             elif type(v) == datetime.datetime:
                 if self.__outcoltypes[k] != TIMESTAMP:
-                    raise RuntimeError("E-UDF.CL.PY-17: emit column '%s' is of type %s but data given have type %s" \
+                    raise RuntimeError("E-UDF.CL.SL.PYTHON-1097: emit column '%s' is of type %s but data given have type %s" \
                             % (decodeUTF8(self.__meta.outputColumnName(k)), type_names.get(self.__outcoltypes[k], 'UNKONWN'), str(type(v))))
                 self.__out.setTimestamp(k, v.isoformat(' '))
-            else: raise RuntimeError("E-UDF.CL.PY-18: data type %s is not supported" % str(type(v)))
+            else: raise RuntimeError("E-UDF.CL.SL.PYTHON-1098: data type %s is not supported" % str(type(v)))
             msg = self.__out.checkException()
-            if msg: raise RuntimeError("F-UDF.CL.PY-19: "+msg)
+            if msg: raise RuntimeError("F-UDF.CL.SL.PYTHON-1099: "+msg)
             k += 1
         ret = self.__out.next()
         msg = self.__out.checkException()
-        if msg: raise RuntimeError("F-UDF.CL.PY-20: "+msg)
-        if ret != True: raise RuntimeError("F-UDF.CL.PY-21: Internal error on emiting row")
+        if msg: raise RuntimeError("F-UDF.CL.SL.PYTHON-1100: "+msg)
+        if ret != True: raise RuntimeError("F-UDF.CL.SL.PYTHON-1101: Internal error on emiting row")
     def next(self, reset = False):
         self.__cache = [None] * len(self.__cache)
         if reset:
@@ -203,23 +203,23 @@ class exaiter(object):
         elif self.__finished: return False
         else: val = self.__inp.next()
         msg = self.__inp.checkException()
-        if msg: raise RuntimeError("F-UDF.CL.PY-22: "+msg)
+        if msg: raise RuntimeError("F-UDF.CL.SL.PYTHON-1102: "+msg)
         if not val:
             self.__finished = True
         return val
     def get_dataframe(self, num_rows=1, start_col=0):
         import pandas
         if not (num_rows == "all" or (type(num_rows) in (int, long) and num_rows > 0)):
-            raise RuntimeError("E-UDF.CL.PY-23: get_dataframe() parameter 'num_rows' must be 'all' or an integer > 0")
+            raise RuntimeError("E-UDF.CL.SL.PYTHON-1103: get_dataframe() parameter 'num_rows' must be 'all' or an integer > 0")
         if (type(start_col) not in (int, long) or start_col < 0):
-            raise RuntimeError("E-UDF.CL.PY-24: get_dataframe() parameter 'start_col' must be an integer >= 0")
+            raise RuntimeError("E-UDF.CL.SL.PYTHON-1104: get_dataframe() parameter 'start_col' must be an integer >= 0")
         if (start_col > len(self.__incolnames)):
-            raise RuntimeError("E-UDF.CL.PY-25: get_dataframe() parameter 'start_col' is %d, but there are only %d input columns" % (start_col, len(self.__incolnames)))
+            raise RuntimeError("E-UDF.CL.SL.PYTHON-1105: get_dataframe() parameter 'start_col' is %d, but there are only %d input columns" % (start_col, len(self.__incolnames)))
         if num_rows == "all":
             num_rows = sys.maxsize
         if self.__dataframe_finished:
             # Exception after None already returned
-            raise RuntimeError("E-UDF.CL.PY-26: Iteration finished")
+            raise RuntimeError("E-UDF.CL.SL.PYTHON-1106: Iteration finished")
         elif self.__finished:
             # Return None the first time there is no data
             self.__dataframe_finished = True
@@ -234,30 +234,30 @@ class exaiter(object):
         return self.__inp.rowsInGroup()
 
 def __disallowed_function(*args, **kw):
-    raise RuntimeError("F-UDF.CL.PY-116: next(), reset() and emit() functions are not allowed in scalar context")
+    raise RuntimeError("F-UDF.CL.SL.PYTHON-1107: next(), reset() and emit() functions are not allowed in scalar context")
 
 def __pythonvm_wrapped_cleanup():
     cleanupfunc = None
     try: cleanupfunc = globals()['cleanup']
-    except: raise RuntimeError("F-UDF.CL.PY-117: function 'cleanup' is not defined")
+    except: raise RuntimeError("F-UDF.CL.SL.PYTHON-1108: function 'cleanup' is not defined")
     try:
         cleanupfunc()
     except BaseException as err:
         raise create_exception_with_complete_backtrace(
-                "F-UDF.CL.PY-119",
+                "F-UDF.CL.SL.PYTHON-1109",
                 "Exception during cleanup",
                 sys.exc_info())
 
 def __pythonvm_wrapped_run():
     runfunc = None
     try: runfunc = globals()['run']
-    except: raise RuntimeError("F-UDF.CL.PY-27: function 'run' is not defined")
+    except: raise RuntimeError("F-UDF.CL.SL.PYTHON-1110: function 'run' is not defined")
     inp = TableIterator(); msg = inp.checkException();
-    if msg: raise RuntimeError("F-UDF.CL.PY-28: "+msg)
+    if msg: raise RuntimeError("F-UDF.CL.SL.PYTHON-1111: "+msg)
     out = ResultHandler(inp); msg = out.checkException();
-    if msg: raise RuntimeError("F-UDF.CL.PY-29: "+msg)
+    if msg: raise RuntimeError("F-UDF.CL.SL.PYTHON-1112: "+msg)
     meta = Metadata(); msg = meta.checkException();
-    if msg: raise RuntimeError("F-UDF.CL.PY-30: "+msg)
+    if msg: raise RuntimeError("F-UDF.CL.SL.PYTHON-1113: "+msg)
     try:
         iter = exaiter(meta, inp, out); iter_next = iter.next; iter_emit = iter.emit
         if meta.outputType() == EXACTLY_ONCE:
@@ -279,7 +279,7 @@ def __pythonvm_wrapped_run():
         out.flush()
     except BaseException as err:
         raise create_exception_with_complete_backtrace(
-                "F-UDF.CL.PY-32",
+                "F-UDF.CL.SL.PYTHON-1114",
                 "Exception during run",
                 sys.exc_info())
 
@@ -333,7 +333,7 @@ def __pythonvm_wrapped_singleCall(fn,arg=None):
                 return fn(imp_spec)
             except BaseException as err:
                 raise create_exception_with_complete_backtrace(
-                        "F-UDF.CL.PY-115",
+                        "F-UDF.CL.SL.PYTHON-1115",
                         "Exception during singleCall %s"%fn.__name__,
                         sys.exc_info())
         elif "generate_sql_for_export_spec" in globals() and fn == generate_sql_for_export_spec:
@@ -344,17 +344,17 @@ def __pythonvm_wrapped_singleCall(fn,arg=None):
                 return fn(exp_spec)
             except BaseException as err:
                 raise create_exception_with_complete_backtrace(
-                        "F-UDF.CL.PY-125",
+                        "F-UDF.CL.SL.PYTHON-1116",
                         "Exception during singleCall %s"%fn.__name__,
                         sys.exc_info())
         else:
-            raise RuntimeError("F-UDF.CL.PY-33: Unknown single call function: "+str(fn))
+            raise RuntimeError("F-UDF.CL.SL.PYTHON-1117: Unknown single call function: "+str(fn))
     else:
         try:
             return fn()
         except BaseException as err:
             raise create_exception_with_complete_backtrace(
-                    "F-UDF.CL.PY-127",
+                    "F-UDF.CL.SL.PYTHON-1118",
                     "Exception during singleCall %s"%fn.__name__,
                     sys.exc_info())
 

--- a/exaudfclient/base/python/exascript_python_wrap.py
+++ b/exaudfclient/base/python/exascript_python_wrap.py
@@ -337,8 +337,8 @@ def __pythonvm_wrapped_singleCall(fn,arg=None):
             except BaseException as err:
                 import traceback
                 backtrace = traceback.format_exc()
-                print("F-UDF.CL.PY-31: Caught exception while executing singleCall %s:\n%s"%(fn.__name__,backtrace))
-                err.args = ("F-UDF.CL.PY-32: Caught exception while executing singleCall %s:\n%s"%(fn.__name__,backtrace),)
+                print("F-UDF.CL.PY-121: Caught exception while executing singleCall %s:\n%s"%(fn.__name__,backtrace))
+                err.args = ("F-UDF.CL.PY-115: Caught exception while executing singleCall %s:\n%s"%(fn.__name__,backtrace),)
                 raise err
         elif "generate_sql_for_export_spec" in globals() and fn == generate_sql_for_export_spec:
             exp_spec = __ExportSpecification(arg)
@@ -349,8 +349,8 @@ def __pythonvm_wrapped_singleCall(fn,arg=None):
             except BaseException as err:
                 import traceback
                 backtrace = traceback.format_exc()
-                print("F-UDF.CL.PY-31: Caught exception while executing singleCall %s:\n%s"%(fn.__name__,backtrace))
-                err.args = ("F-UDF.CL.PY-32: Caught exception while executing singleCall %s:\n%s"%(fn.__name__,backtrace),)
+                print("F-UDF.CL.PY-124: Caught exception while executing singleCall %s:\n%s"%(fn.__name__,backtrace))
+                err.args = ("F-UDF.CL.PY-125: Caught exception while executing singleCall %s:\n%s"%(fn.__name__,backtrace),)
                 raise err
         else:
             raise RuntimeError("F-UDF.CL.PY-33: Unknown single call function: "+str(fn))
@@ -360,6 +360,6 @@ def __pythonvm_wrapped_singleCall(fn,arg=None):
         except BaseException as err:
             import traceback
             backtrace = traceback.format_exc()
-            print("F-UDF.CL.PY-31: Caught exception while executing singleCall %s:\n%s"%(fn.__name__,backtrace))
-            err.args = ("F-UDF.CL.PY-32: Caught exception while executing singleCall %s:\n%s"%(fn.__name__,backtrace),)
+            print("F-UDF.CL.PY-126: Caught exception while executing singleCall %s:\n%s"%(fn.__name__,backtrace))
+            err.args = ("F-UDF.CL.PY-127: Caught exception while executing singleCall %s:\n%s"%(fn.__name__,backtrace),)
             raise err

--- a/exaudfclient/base/python/python3/python_ext_dataframe.cc
+++ b/exaudfclient/base/python/python3/python_ext_dataframe.cc
@@ -73,7 +73,7 @@ std::map<int, std::string> emitTypeMap {
 inline void checkPyObjectIsNull(const PyObject *obj) {
     // Error message set by Python
     if (!obj)
-        throw std::runtime_error("");
+        throw std::runtime_error("F-UDF.CL.PY-72");
 }
 
 
@@ -110,7 +110,7 @@ struct PyPtr {
 inline void checkPyPtrIsNull(const PyPtr& obj) {
     // Error message set by Python
     if (!obj)
-        throw std::runtime_error("");
+        throw std::runtime_error("F-UDF.CL.PY-73");
 }
 
 
@@ -142,20 +142,20 @@ void getColumnInfo(PyObject *ctxIter, PyObject *colNames, long startCol, std::ve
     PyPtr pyColTypes(PyObject_GetAttrString(ctxIter, ctxColumnTypeList));
     if (!PyList_Check(pyColTypes.get())) {
         std::stringstream ss;
-        ss << "getColumnInfo: " << ctxColumnTypeList << " is not a list";
+        ss << "F-UDF.CL.PY-74: " << "getColumnInfo: " << ctxColumnTypeList << " is not a list";
         throw std::runtime_error(ss.str().c_str());
     }
 
     if (!PyList_Check(colNames)) {
         std::stringstream ss;
-        ss << "getColumnInfo: colNames is not a list";
+        ss << "F-UDF.CL.PY-75: " << "getColumnInfo: colNames is not a list";
         throw std::runtime_error(ss.str().c_str());
     }
 
     Py_ssize_t pyNumCols = PyList_Size(pyColTypes.get());
     if (pyNumCols != PyList_Size(colNames)) {
         std::stringstream ss;
-        ss << "getColumnInfo: ";
+        ss << "F-UDF.CL.PY-76" << "getColumnInfo: ";
         ss << ctxColumnTypeList << " has length " << pyNumCols << ", but ";
         ss << "colNames has length " << PyList_Size(colNames);
         throw std::runtime_error(ss.str().c_str());
@@ -166,13 +166,13 @@ void getColumnInfo(PyObject *ctxIter, PyObject *colNames, long startCol, std::ve
         checkPyObjectIsNull(pyColType);
         int colType = PyLong_AsLong(pyColType);
         if (colType < 0 && PyErr_Occurred())
-            throw std::runtime_error("getColumnInfo(): PyLong_AsLong error");
+            throw std::runtime_error("F-UDF.CL.PY-77 getColumnInfo(): PyLong_AsLong error");
 
         PyObject *pyColName = PyList_GetItem(colNames, i);
         checkPyObjectIsNull(pyColName);
         const char *colName = PyUnicode_AsUTF8(pyColName);
         if (!colName)
-            throw std::runtime_error("");
+            throw std::runtime_error("F-UDF.CL.PY-78");
 
         colInfo.push_back(ColumnInfo(std::string(colName), colType));
     }
@@ -255,7 +255,7 @@ PyObject *getColumnData(std::vector<ColumnInfo>& colInfo, PyObject *tableIter, l
             default:
             {
                 std::stringstream ss;
-                ss << "getColumnData(): unexpected type " << colInfo[i].type;
+                ss << "F-UDF.CL.PY-79" << "getColumnData(): unexpected type " << colInfo[i].type;
                 throw std::runtime_error(ss.str().c_str());
             }
         }
@@ -263,7 +263,7 @@ PyObject *getColumnData(std::vector<ColumnInfo>& colInfo, PyObject *tableIter, l
 
         Py_ssize_t colNum = PyLong_AsSsize_t(pyColNum.get());
         if (colNum < 0 && PyErr_Occurred())
-            throw std::runtime_error("getColumnData(): PyLong_AsSsize_t error");
+            throw std::runtime_error("F-UDF.CL.PY-80: getColumnData(): PyLong_AsSsize_t error");
 
         pyColGetMethods.push_back(std::make_tuple(colNum, std::move(pyColNum), std::move(pyMethodName), postFunction));
     }
@@ -282,7 +282,7 @@ PyObject *getColumnData(std::vector<ColumnInfo>& colInfo, PyObject *tableIter, l
                 PyObject *ptype, *pvalue, *ptraceback;
                 PyErr_Fetch(&ptype, &pvalue, &ptraceback);
                 std::stringstream ss;
-                ss << "getColumnData(): Error fetching value for row " << r << ", column " << c << ": ";
+                ss << "F-UDF.CL.PY-81: getColumnData(): Error fetching value for row " << r << ", column " << c << ": ";
                 ss << PyUnicode_AsUTF8(pvalue);
                 throw std::runtime_error(ss.str().c_str());
             }
@@ -292,7 +292,7 @@ PyObject *getColumnData(std::vector<ColumnInfo>& colInfo, PyObject *tableIter, l
                 const char *exMsg = PyUnicode_AsUTF8(pyCheckException.get());
                 if (exMsg) {
                     std::stringstream ss;
-                    ss << "getColumnData(): get row " << r << ", column " << c << ": " << exMsg;
+                    ss << "F-UDF.CL.PY-82: getColumnData(): get row " << r << ", column " << c << ": " << exMsg;
                     throw std::runtime_error(ss.str().c_str());
                 }
             }
@@ -300,7 +300,7 @@ PyObject *getColumnData(std::vector<ColumnInfo>& colInfo, PyObject *tableIter, l
             PyPtr pyWasNull(PyObject_CallMethodObjArgs(tableIter, pyWasNullMethodName.get(), NULL));
             int wasNull = PyObject_IsTrue(pyWasNull.get());
             if (wasNull < 0)
-                throw std::runtime_error("getColumnData(): wasNull() PyObject_IsTrue() error");
+                throw std::runtime_error("F-UDF.CL.PY-83: getColumnData(): wasNull() PyObject_IsTrue() error");
 
             if (wasNull) {
                 Py_INCREF(Py_None);
@@ -316,7 +316,7 @@ PyObject *getColumnData(std::vector<ColumnInfo>& colInfo, PyObject *tableIter, l
 
         int ok = PyList_Append(pyData.get(), pyRow.get());
         if (ok < 0)
-            throw std::runtime_error("getColumnData(): PyList_Append error");
+            throw std::runtime_error("F-UDF.CL.PY-84: getColumnData(): PyList_Append error");
 
         if (isSetInput) {
             PyPtr pyNext(PyObject_CallMethodObjArgs(tableIter, pyNextMethodName.get(), NULL));
@@ -326,14 +326,14 @@ PyObject *getColumnData(std::vector<ColumnInfo>& colInfo, PyObject *tableIter, l
                 const char *exMsg = PyUnicode_AsUTF8(pyCheckException.get());
                 if (exMsg) {
                     std::stringstream ss;
-                    ss << "getColumnData(): next(): " << exMsg;
+                    ss << "F-UDF.CL.PY-85: getColumnData(): next(): " << exMsg;
                     throw std::runtime_error(ss.str().c_str());
                 }
             }
 
             int next = PyObject_IsTrue(pyNext.get());
             if (next < 0) {
-                throw std::runtime_error("getColumnData(): next() PyObject_IsTrue() error");
+                throw std::runtime_error("F-UDF.CL.PY-86: getColumnData(): next() PyObject_IsTrue() error");
             }
             else if (!next) {
                 isFinished = true;
@@ -380,7 +380,7 @@ void emit(PyObject *resultHandler, std::vector<ColumnInfo>& colInfo, PyObject *d
             default:
             {
                 std::stringstream ss;
-                ss << "emit(): unexpected type " << emitTypeMap.at(colInfo[i].type);
+                ss << "F-UDF.CL.PY-87: emit(): unexpected type " << emitTypeMap.at(colInfo[i].type);
                 throw std::runtime_error(ss.str().c_str());
             }
         }
@@ -400,7 +400,7 @@ void emit(PyObject *resultHandler, std::vector<ColumnInfo>& colInfo, PyObject *d
         }
         else {
             std::stringstream ss;
-            ss << "emit: unexpected type: " << typeName;
+            ss << "F-UDF.CL.PY-88: emit: unexpected type: " << typeName;
             throw std::runtime_error(ss.str().c_str());
         }
     }
@@ -429,7 +429,7 @@ void emit(PyObject *resultHandler, std::vector<ColumnInfo>& colInfo, PyObject *d
             PyPtr pyList(PyObject_CallMethod(array.get(), "tolist", NULL));
             if (!PyList_Check(pyList.get())) {
                 std::stringstream ss;
-                ss << "emit(): column array " << c << " is not a list";
+                ss << "F-UDF.CL.PY-89: emit(): column array " << c << " is not a list";
                 throw std::runtime_error(ss.str().c_str());
             }
 
@@ -454,7 +454,7 @@ void emit(PyObject *resultHandler, std::vector<ColumnInfo>& colInfo, PyObject *d
             }
             else {
                 std::stringstream ss;
-                ss << "emit: column " <<  c << ", unexpected python type: " << pyTypeName;
+                ss << "F-UDF.CL.PY-90: emit: column " <<  c << ", unexpected python type: " << pyTypeName;
                 throw std::runtime_error(ss.str().c_str());
             }
 
@@ -465,7 +465,7 @@ void emit(PyObject *resultHandler, std::vector<ColumnInfo>& colInfo, PyObject *d
             PyPtr pyList(PyObject_CallMethod(array.get(), "tolist", NULL));
             if (!PyList_Check(pyList.get())) {
                 std::stringstream ss;
-                ss << "emit(): column array " << c << " is not a list";
+                ss << "F-UDF.CL.PY-91: emit(): column array " << c << " is not a list";
                 throw std::runtime_error(ss.str().c_str());
             }
 
@@ -518,7 +518,7 @@ void emit(PyObject *resultHandler, std::vector<ColumnInfo>& colInfo, PyObject *d
                         default:
                         {
                             std::stringstream ss;
-                            ss << "emit column " << c << " of type " << emitTypeMap.at(colInfo[c].type) << " but data given have type " << colTypes[c].first;
+                            ss << "F-UDF.CL.PY-92: emit column " << c << " of type " << emitTypeMap.at(colInfo[c].type) << " but data given have type " << colTypes[c].first;
                             throw std::runtime_error(ss.str().c_str());
                         }
                     }
@@ -548,7 +548,7 @@ void emit(PyObject *resultHandler, std::vector<ColumnInfo>& colInfo, PyObject *d
                         default:
                         {
                             std::stringstream ss;
-                            ss << "emit column " << c << " of type " << emitTypeMap.at(colInfo[c].type) << " but data given have type " << colTypes[c].first;
+                            ss << "F-UDF.CL.PY-93: emit column " << c << " of type " << emitTypeMap.at(colInfo[c].type) << " but data given have type " << colTypes[c].first;
                             throw std::runtime_error(ss.str().c_str());
                         }
                     }
@@ -578,7 +578,7 @@ void emit(PyObject *resultHandler, std::vector<ColumnInfo>& colInfo, PyObject *d
                         default:
                         {
                             std::stringstream ss;
-                            ss << "emit column " << c << " of type " << emitTypeMap.at(colInfo[c].type) << " but data given have type " << colTypes[c].first;
+                            ss << "F-UDF.CL.PY-94: emit column " << c << " of type " << emitTypeMap.at(colInfo[c].type) << " but data given have type " << colTypes[c].first;
                             throw std::runtime_error(ss.str().c_str());
                         }
                     }
@@ -608,7 +608,7 @@ void emit(PyObject *resultHandler, std::vector<ColumnInfo>& colInfo, PyObject *d
                         default:
                         {
                             std::stringstream ss;
-                            ss << "emit column " << c << " of type " << emitTypeMap.at(colInfo[c].type) << " but data given have type " << colTypes[c].first;
+                            ss << "F-UDF.CL.PY-95: emit column " << c << " of type " << emitTypeMap.at(colInfo[c].type) << " but data given have type " << colTypes[c].first;
                             throw std::runtime_error(ss.str().c_str());
                         }
                     }
@@ -637,7 +637,7 @@ void emit(PyObject *resultHandler, std::vector<ColumnInfo>& colInfo, PyObject *d
                         default:
                         {
                             std::stringstream ss;
-                            ss << "emit column " << c << " of type " << emitTypeMap.at(colInfo[c].type) << " but data given have type " << colTypes[c].first;
+                            ss << "F-UDF.CL.PY-96: emit column " << c << " of type " << emitTypeMap.at(colInfo[c].type) << " but data given have type " << colTypes[c].first;
                             throw std::runtime_error(ss.str().c_str());
                         }
                     }
@@ -666,7 +666,7 @@ void emit(PyObject *resultHandler, std::vector<ColumnInfo>& colInfo, PyObject *d
                         default:
                         {
                             std::stringstream ss;
-                            ss << "emit column " << c << " of type " << emitTypeMap.at(colInfo[c].type) << " but data given have type " << colTypes[c].first;
+                            ss << "F-UDF.CL.PY-97: emit column " << c << " of type " << emitTypeMap.at(colInfo[c].type) << " but data given have type " << colTypes[c].first;
                             throw std::runtime_error(ss.str().c_str());
                         }
                     }
@@ -695,7 +695,7 @@ void emit(PyObject *resultHandler, std::vector<ColumnInfo>& colInfo, PyObject *d
                         default:
                         {
                             std::stringstream ss;
-                            ss << "emit column " << c << " of type " << emitTypeMap.at(colInfo[c].type) << " but data given have type " << colTypes[c].first;
+                            ss << "F-UDF.CL.PY-98: emit column " << c << " of type " << emitTypeMap.at(colInfo[c].type) << " but data given have type " << colTypes[c].first;
                             throw std::runtime_error(ss.str().c_str());
                         }
                     }
@@ -724,7 +724,7 @@ void emit(PyObject *resultHandler, std::vector<ColumnInfo>& colInfo, PyObject *d
                         default:
                         {
                             std::stringstream ss;
-                            ss << "emit column " << c << " of type " << emitTypeMap.at(colInfo[c].type) << " but data given have type " << colTypes[c].first;
+                            ss << "F-UDF.CL.PY-99: emit column " << c << " of type " << emitTypeMap.at(colInfo[c].type) << " but data given have type " << colTypes[c].first;
                             throw std::runtime_error(ss.str().c_str());
                         }
                     }
@@ -757,7 +757,7 @@ void emit(PyObject *resultHandler, std::vector<ColumnInfo>& colInfo, PyObject *d
                         default:
                         {
                             std::stringstream ss;
-                            ss << "emit column " << c << " of type " << emitTypeMap.at(colInfo[c].type) << " but data given have type " << colTypes[c].first;
+                            ss << "F-UDF.CL.PY-100: emit column " << c << " of type " << emitTypeMap.at(colInfo[c].type) << " but data given have type " << colTypes[c].first;
                             throw std::runtime_error(ss.str().c_str());
                         }
                     }
@@ -786,14 +786,14 @@ void emit(PyObject *resultHandler, std::vector<ColumnInfo>& colInfo, PyObject *d
                         {
                             double value = PyFloat_AsDouble(pyInt.get());
                             if (value < 0 && PyErr_Occurred())
-                                throw std::runtime_error("emit() PY_INT: PyFloat_AsDouble error");
+                                throw std::runtime_error("F-UDF.CL.PY-101: emit() PY_INT: PyFloat_AsDouble error");
                             pyValue.reset(PyFloat_FromDouble(value));
                             break;
                         }
                         default:
                         {
                             std::stringstream ss;
-                            ss << "emit column " << c << " of type " << emitTypeMap.at(colInfo[c].type) << " but data given have type " << colTypes[c].first;
+                            ss << "F-UDF.CL.PY-102: emit column " << c << " of type " << emitTypeMap.at(colInfo[c].type) << " but data given have type " << colTypes[c].first;
                             throw std::runtime_error(ss.str().c_str());
                         }
                     }
@@ -828,7 +828,7 @@ void emit(PyObject *resultHandler, std::vector<ColumnInfo>& colInfo, PyObject *d
                         default:
                         {
                             std::stringstream ss;
-                            ss << "emit column " << c << " of type " << emitTypeMap.at(colInfo[c].type) << " but data given have type " << colTypes[c].first;
+                            ss << "F-UDF.CL.PY-103: emit column " << c << " of type " << emitTypeMap.at(colInfo[c].type) << " but data given have type " << colTypes[c].first;
                             throw std::runtime_error(ss.str().c_str());
                         }
                     }
@@ -860,7 +860,7 @@ void emit(PyObject *resultHandler, std::vector<ColumnInfo>& colInfo, PyObject *d
                         default:
                         {
                             std::stringstream ss;
-                            ss << "emit column " << c << " of type " << emitTypeMap.at(colInfo[c].type) << " but data given have type " << colTypes[c].first;
+                            ss << "F-UDF.CL.PY-104: emit column " << c << " of type " << emitTypeMap.at(colInfo[c].type) << " but data given have type " << colTypes[c].first;
                             throw std::runtime_error(ss.str().c_str());
                         }
                     }
@@ -884,7 +884,7 @@ void emit(PyObject *resultHandler, std::vector<ColumnInfo>& colInfo, PyObject *d
                         default:
                         {
                             std::stringstream ss;
-                            ss << "emit column " << c << " of type " << emitTypeMap.at(colInfo[c].type) << " but data given have type " << colTypes[c].first;
+                            ss << "F-UDF.CL.PY-105: emit column " << c << " of type " << emitTypeMap.at(colInfo[c].type) << " but data given have type " << colTypes[c].first;
                             throw std::runtime_error(ss.str().c_str());
                         }
                     }
@@ -908,7 +908,7 @@ void emit(PyObject *resultHandler, std::vector<ColumnInfo>& colInfo, PyObject *d
                         default:
                         {
                             std::stringstream ss;
-                            ss << "emit column " << c << " of type " << emitTypeMap.at(colInfo[c].type) << " but data given have type " << colTypes[c].first;
+                            ss << "F-UDF.CL.PY-106: emit column " << c << " of type " << emitTypeMap.at(colInfo[c].type) << " but data given have type " << colTypes[c].first;
                             throw std::runtime_error(ss.str().c_str());
                         }
                     }
@@ -922,7 +922,7 @@ void emit(PyObject *resultHandler, std::vector<ColumnInfo>& colInfo, PyObject *d
                 default:
                 {
                     std::stringstream ss;
-                    ss << "emit: unexpected type: " << colTypes[c].first;
+                    ss << "F-UDF.CL.PY-107: emit: unexpected type: " << colTypes[c].first;
                     throw std::runtime_error(ss.str().c_str());
                 }
             }
@@ -932,7 +932,7 @@ void emit(PyObject *resultHandler, std::vector<ColumnInfo>& colInfo, PyObject *d
                 PyErr_Fetch(&ptype, &pvalue, &ptraceback);
                 if (pvalue) {
                     std::stringstream ss;
-                    ss << "emit(): Error setting value for row " << r << ", column " << c << ": ";
+                    ss << "F-UDF.CL.PY-108: emit(): Error setting value for row " << r << ", column " << c << ": ";
                     ss << PyUnicode_AsUTF8(pvalue);
                     throw std::runtime_error(ss.str().c_str());
                 }
@@ -943,7 +943,7 @@ void emit(PyObject *resultHandler, std::vector<ColumnInfo>& colInfo, PyObject *d
                 const char *exMsg = PyUnicode_AsUTF8(pyCheckException.get());
                 if (exMsg) {
                     std::stringstream ss;
-                    ss << "emit(): " << exMsg;
+                    ss << "F-UDF.CL.PY-109: emit(): " << exMsg;
                     throw std::runtime_error(ss.str().c_str());
                 }
             }
@@ -981,7 +981,7 @@ PyObject *getNumpyTypes(PyObject *dataframe)
 
     if (!PyList_Check(pyDtypeValues.get())) {
         std::stringstream ss;
-        ss << "DataFrame.dtypes.values is not a list";
+        ss << "F-UDF.CL.PY-110: DataFrame.dtypes.values is not a list";
         throw std::runtime_error(ss.str().c_str());
     }
 
@@ -1001,7 +1001,7 @@ void getOutputColumnTypes(PyObject *colTypes, std::vector<ColumnInfo>& colInfo)
 {
     if (!PyList_Check(colTypes)) {
         std::stringstream ss;
-        ss << "getOutputColumnTypes(): colTypes is not a list";
+        ss << "F-UDF.CL.PY-111: getOutputColumnTypes(): colTypes is not a list";
         throw std::runtime_error(ss.str().c_str());
     }
 
@@ -1011,7 +1011,7 @@ void getOutputColumnTypes(PyObject *colTypes, std::vector<ColumnInfo>& colInfo)
         checkPyObjectIsNull(pyColType);
         int colType = PyLong_AsLong(pyColType);
         if (colType < 0 && PyErr_Occurred())
-            throw std::runtime_error("getColumnInfo(): PyLong_AsLong error");
+            throw std::runtime_error("F-UDF.CL.PY-112: getColumnInfo(): PyLong_AsLong error");
 
         colInfo.push_back(ColumnInfo(std::to_string(i), colType));
     }
@@ -1034,7 +1034,7 @@ static PyObject *getDataframe(PyObject *self, PyObject *args)
         PyPtr pyInputType(PyObject_GetAttrString(ctxIter, "_exaiter__intype"));
         int inputType = PyLong_AsLong(pyInputType.get());
         if (inputType < 0 && PyErr_Occurred())
-            throw std::runtime_error("getDataframe(): PyLong_AsLong error");
+            throw std::runtime_error("F-UDF.CL.PY-113: getDataframe(): PyLong_AsLong error");
 
         // Get script input type
         bool isSetInput = (static_cast<SWIGVMContainers::SWIGVM_itertype_e>(inputType) == SWIGVMContainers::MULTIPLE);
@@ -1049,7 +1049,7 @@ static PyObject *getDataframe(PyObject *self, PyObject *args)
         if (isFinished) {
             int ok = PyObject_SetAttrString(ctxIter, "_exaiter__finished", Py_True);
             if (ok < 0)
-                throw std::runtime_error("getDataframe(): error setting exaiter.__finished");
+                throw std::runtime_error("F-UDF.CL.PY-114: getDataframe(): error setting exaiter.__finished");
         }
         // Create DataFrame
         pyDataFrame.reset(createDataFrame(pyData.get(), colInfo));

--- a/exaudfclient/base/python/python3/python_ext_dataframe.cc
+++ b/exaudfclient/base/python/python3/python_ext_dataframe.cc
@@ -73,7 +73,7 @@ std::map<int, std::string> emitTypeMap {
 inline void checkPyObjectIsNull(const PyObject *obj) {
     // Error message set by Python
     if (!obj)
-        throw std::runtime_error("F-UDF.CL.PY-72");
+        throw std::runtime_error("F-UDF.CL.SL.PYTHON-1038");
 }
 
 
@@ -110,7 +110,7 @@ struct PyPtr {
 inline void checkPyPtrIsNull(const PyPtr& obj) {
     // Error message set by Python
     if (!obj)
-        throw std::runtime_error("F-UDF.CL.PY-73");
+        throw std::runtime_error("F-UDF.CL.SL.PYTHON-1039");
 }
 
 
@@ -142,20 +142,20 @@ void getColumnInfo(PyObject *ctxIter, PyObject *colNames, long startCol, std::ve
     PyPtr pyColTypes(PyObject_GetAttrString(ctxIter, ctxColumnTypeList));
     if (!PyList_Check(pyColTypes.get())) {
         std::stringstream ss;
-        ss << "F-UDF.CL.PY-74: " << "getColumnInfo: " << ctxColumnTypeList << " is not a list";
+        ss << "F-UDF.CL.SL.PYTHON-1040: " << "getColumnInfo: " << ctxColumnTypeList << " is not a list";
         throw std::runtime_error(ss.str().c_str());
     }
 
     if (!PyList_Check(colNames)) {
         std::stringstream ss;
-        ss << "F-UDF.CL.PY-75: " << "getColumnInfo: colNames is not a list";
+        ss << "F-UDF.CL.SL.PYTHON-1041: " << "getColumnInfo: colNames is not a list";
         throw std::runtime_error(ss.str().c_str());
     }
 
     Py_ssize_t pyNumCols = PyList_Size(pyColTypes.get());
     if (pyNumCols != PyList_Size(colNames)) {
         std::stringstream ss;
-        ss << "F-UDF.CL.PY-76" << "getColumnInfo: ";
+        ss << "F-UDF.CL.SL.PYTHON-1042" << "getColumnInfo: ";
         ss << ctxColumnTypeList << " has length " << pyNumCols << ", but ";
         ss << "colNames has length " << PyList_Size(colNames);
         throw std::runtime_error(ss.str().c_str());
@@ -166,13 +166,13 @@ void getColumnInfo(PyObject *ctxIter, PyObject *colNames, long startCol, std::ve
         checkPyObjectIsNull(pyColType);
         int colType = PyLong_AsLong(pyColType);
         if (colType < 0 && PyErr_Occurred())
-            throw std::runtime_error("F-UDF.CL.PY-77 getColumnInfo(): PyLong_AsLong error");
+            throw std::runtime_error("F-UDF.CL.SL.PYTHON-1043 getColumnInfo(): PyLong_AsLong error");
 
         PyObject *pyColName = PyList_GetItem(colNames, i);
         checkPyObjectIsNull(pyColName);
         const char *colName = PyUnicode_AsUTF8(pyColName);
         if (!colName)
-            throw std::runtime_error("F-UDF.CL.PY-78");
+            throw std::runtime_error("F-UDF.CL.SL.PYTHON-1044");
 
         colInfo.push_back(ColumnInfo(std::string(colName), colType));
     }
@@ -255,7 +255,7 @@ PyObject *getColumnData(std::vector<ColumnInfo>& colInfo, PyObject *tableIter, l
             default:
             {
                 std::stringstream ss;
-                ss << "F-UDF.CL.PY-79" << "getColumnData(): unexpected type " << colInfo[i].type;
+                ss << "F-UDF.CL.SL.PYTHON-1045" << "getColumnData(): unexpected type " << colInfo[i].type;
                 throw std::runtime_error(ss.str().c_str());
             }
         }
@@ -263,7 +263,7 @@ PyObject *getColumnData(std::vector<ColumnInfo>& colInfo, PyObject *tableIter, l
 
         Py_ssize_t colNum = PyLong_AsSsize_t(pyColNum.get());
         if (colNum < 0 && PyErr_Occurred())
-            throw std::runtime_error("F-UDF.CL.PY-80: getColumnData(): PyLong_AsSsize_t error");
+            throw std::runtime_error("F-UDF.CL.SL.PYTHON-1046: getColumnData(): PyLong_AsSsize_t error");
 
         pyColGetMethods.push_back(std::make_tuple(colNum, std::move(pyColNum), std::move(pyMethodName), postFunction));
     }
@@ -282,7 +282,7 @@ PyObject *getColumnData(std::vector<ColumnInfo>& colInfo, PyObject *tableIter, l
                 PyObject *ptype, *pvalue, *ptraceback;
                 PyErr_Fetch(&ptype, &pvalue, &ptraceback);
                 std::stringstream ss;
-                ss << "F-UDF.CL.PY-81: getColumnData(): Error fetching value for row " << r << ", column " << c << ": ";
+                ss << "F-UDF.CL.SL.PYTHON-1047: getColumnData(): Error fetching value for row " << r << ", column " << c << ": ";
                 ss << PyUnicode_AsUTF8(pvalue);
                 throw std::runtime_error(ss.str().c_str());
             }
@@ -292,7 +292,7 @@ PyObject *getColumnData(std::vector<ColumnInfo>& colInfo, PyObject *tableIter, l
                 const char *exMsg = PyUnicode_AsUTF8(pyCheckException.get());
                 if (exMsg) {
                     std::stringstream ss;
-                    ss << "F-UDF.CL.PY-82: getColumnData(): get row " << r << ", column " << c << ": " << exMsg;
+                    ss << "F-UDF.CL.SL.PYTHON-1048: getColumnData(): get row " << r << ", column " << c << ": " << exMsg;
                     throw std::runtime_error(ss.str().c_str());
                 }
             }
@@ -300,7 +300,7 @@ PyObject *getColumnData(std::vector<ColumnInfo>& colInfo, PyObject *tableIter, l
             PyPtr pyWasNull(PyObject_CallMethodObjArgs(tableIter, pyWasNullMethodName.get(), NULL));
             int wasNull = PyObject_IsTrue(pyWasNull.get());
             if (wasNull < 0)
-                throw std::runtime_error("F-UDF.CL.PY-83: getColumnData(): wasNull() PyObject_IsTrue() error");
+                throw std::runtime_error("F-UDF.CL.SL.PYTHON-1049: getColumnData(): wasNull() PyObject_IsTrue() error");
 
             if (wasNull) {
                 Py_INCREF(Py_None);
@@ -316,7 +316,7 @@ PyObject *getColumnData(std::vector<ColumnInfo>& colInfo, PyObject *tableIter, l
 
         int ok = PyList_Append(pyData.get(), pyRow.get());
         if (ok < 0)
-            throw std::runtime_error("F-UDF.CL.PY-84: getColumnData(): PyList_Append error");
+            throw std::runtime_error("F-UDF.CL.SL.PYTHON-1050: getColumnData(): PyList_Append error");
 
         if (isSetInput) {
             PyPtr pyNext(PyObject_CallMethodObjArgs(tableIter, pyNextMethodName.get(), NULL));
@@ -326,14 +326,14 @@ PyObject *getColumnData(std::vector<ColumnInfo>& colInfo, PyObject *tableIter, l
                 const char *exMsg = PyUnicode_AsUTF8(pyCheckException.get());
                 if (exMsg) {
                     std::stringstream ss;
-                    ss << "F-UDF.CL.PY-85: getColumnData(): next(): " << exMsg;
+                    ss << "F-UDF.CL.SL.PYTHON-1051: getColumnData(): next(): " << exMsg;
                     throw std::runtime_error(ss.str().c_str());
                 }
             }
 
             int next = PyObject_IsTrue(pyNext.get());
             if (next < 0) {
-                throw std::runtime_error("F-UDF.CL.PY-86: getColumnData(): next() PyObject_IsTrue() error");
+                throw std::runtime_error("F-UDF.CL.SL.PYTHON-1052: getColumnData(): next() PyObject_IsTrue() error");
             }
             else if (!next) {
                 isFinished = true;
@@ -380,7 +380,7 @@ void emit(PyObject *resultHandler, std::vector<ColumnInfo>& colInfo, PyObject *d
             default:
             {
                 std::stringstream ss;
-                ss << "F-UDF.CL.PY-87: emit(): unexpected type " << emitTypeMap.at(colInfo[i].type);
+                ss << "F-UDF.CL.SL.PYTHON-1053: emit(): unexpected type " << emitTypeMap.at(colInfo[i].type);
                 throw std::runtime_error(ss.str().c_str());
             }
         }
@@ -400,7 +400,7 @@ void emit(PyObject *resultHandler, std::vector<ColumnInfo>& colInfo, PyObject *d
         }
         else {
             std::stringstream ss;
-            ss << "F-UDF.CL.PY-88: emit: unexpected type: " << typeName;
+            ss << "F-UDF.CL.SL.PYTHON-1054: emit: unexpected type: " << typeName;
             throw std::runtime_error(ss.str().c_str());
         }
     }
@@ -429,7 +429,7 @@ void emit(PyObject *resultHandler, std::vector<ColumnInfo>& colInfo, PyObject *d
             PyPtr pyList(PyObject_CallMethod(array.get(), "tolist", NULL));
             if (!PyList_Check(pyList.get())) {
                 std::stringstream ss;
-                ss << "F-UDF.CL.PY-89: emit(): column array " << c << " is not a list";
+                ss << "F-UDF.CL.SL.PYTHON-1055: emit(): column array " << c << " is not a list";
                 throw std::runtime_error(ss.str().c_str());
             }
 
@@ -454,7 +454,7 @@ void emit(PyObject *resultHandler, std::vector<ColumnInfo>& colInfo, PyObject *d
             }
             else {
                 std::stringstream ss;
-                ss << "F-UDF.CL.PY-90: emit: column " <<  c << ", unexpected python type: " << pyTypeName;
+                ss << "F-UDF.CL.SL.PYTHON-1056: emit: column " <<  c << ", unexpected python type: " << pyTypeName;
                 throw std::runtime_error(ss.str().c_str());
             }
 
@@ -465,7 +465,7 @@ void emit(PyObject *resultHandler, std::vector<ColumnInfo>& colInfo, PyObject *d
             PyPtr pyList(PyObject_CallMethod(array.get(), "tolist", NULL));
             if (!PyList_Check(pyList.get())) {
                 std::stringstream ss;
-                ss << "F-UDF.CL.PY-91: emit(): column array " << c << " is not a list";
+                ss << "F-UDF.CL.SL.PYTHON-1057: emit(): column array " << c << " is not a list";
                 throw std::runtime_error(ss.str().c_str());
             }
 
@@ -518,7 +518,7 @@ void emit(PyObject *resultHandler, std::vector<ColumnInfo>& colInfo, PyObject *d
                         default:
                         {
                             std::stringstream ss;
-                            ss << "F-UDF.CL.PY-92: emit column " << c << " of type " << emitTypeMap.at(colInfo[c].type) << " but data given have type " << colTypes[c].first;
+                            ss << "F-UDF.CL.SL.PYTHON-1058: emit column " << c << " of type " << emitTypeMap.at(colInfo[c].type) << " but data given have type " << colTypes[c].first;
                             throw std::runtime_error(ss.str().c_str());
                         }
                     }
@@ -548,7 +548,7 @@ void emit(PyObject *resultHandler, std::vector<ColumnInfo>& colInfo, PyObject *d
                         default:
                         {
                             std::stringstream ss;
-                            ss << "F-UDF.CL.PY-93: emit column " << c << " of type " << emitTypeMap.at(colInfo[c].type) << " but data given have type " << colTypes[c].first;
+                            ss << "F-UDF.CL.SL.PYTHON-1059: emit column " << c << " of type " << emitTypeMap.at(colInfo[c].type) << " but data given have type " << colTypes[c].first;
                             throw std::runtime_error(ss.str().c_str());
                         }
                     }
@@ -578,7 +578,7 @@ void emit(PyObject *resultHandler, std::vector<ColumnInfo>& colInfo, PyObject *d
                         default:
                         {
                             std::stringstream ss;
-                            ss << "F-UDF.CL.PY-94: emit column " << c << " of type " << emitTypeMap.at(colInfo[c].type) << " but data given have type " << colTypes[c].first;
+                            ss << "F-UDF.CL.SL.PYTHON-1060: emit column " << c << " of type " << emitTypeMap.at(colInfo[c].type) << " but data given have type " << colTypes[c].first;
                             throw std::runtime_error(ss.str().c_str());
                         }
                     }
@@ -608,7 +608,7 @@ void emit(PyObject *resultHandler, std::vector<ColumnInfo>& colInfo, PyObject *d
                         default:
                         {
                             std::stringstream ss;
-                            ss << "F-UDF.CL.PY-95: emit column " << c << " of type " << emitTypeMap.at(colInfo[c].type) << " but data given have type " << colTypes[c].first;
+                            ss << "F-UDF.CL.SL.PYTHON-1061: emit column " << c << " of type " << emitTypeMap.at(colInfo[c].type) << " but data given have type " << colTypes[c].first;
                             throw std::runtime_error(ss.str().c_str());
                         }
                     }
@@ -637,7 +637,7 @@ void emit(PyObject *resultHandler, std::vector<ColumnInfo>& colInfo, PyObject *d
                         default:
                         {
                             std::stringstream ss;
-                            ss << "F-UDF.CL.PY-96: emit column " << c << " of type " << emitTypeMap.at(colInfo[c].type) << " but data given have type " << colTypes[c].first;
+                            ss << "F-UDF.CL.SL.PYTHON-1062: emit column " << c << " of type " << emitTypeMap.at(colInfo[c].type) << " but data given have type " << colTypes[c].first;
                             throw std::runtime_error(ss.str().c_str());
                         }
                     }
@@ -666,7 +666,7 @@ void emit(PyObject *resultHandler, std::vector<ColumnInfo>& colInfo, PyObject *d
                         default:
                         {
                             std::stringstream ss;
-                            ss << "F-UDF.CL.PY-97: emit column " << c << " of type " << emitTypeMap.at(colInfo[c].type) << " but data given have type " << colTypes[c].first;
+                            ss << "F-UDF.CL.SL.PYTHON-1063: emit column " << c << " of type " << emitTypeMap.at(colInfo[c].type) << " but data given have type " << colTypes[c].first;
                             throw std::runtime_error(ss.str().c_str());
                         }
                     }
@@ -695,7 +695,7 @@ void emit(PyObject *resultHandler, std::vector<ColumnInfo>& colInfo, PyObject *d
                         default:
                         {
                             std::stringstream ss;
-                            ss << "F-UDF.CL.PY-98: emit column " << c << " of type " << emitTypeMap.at(colInfo[c].type) << " but data given have type " << colTypes[c].first;
+                            ss << "F-UDF.CL.SL.PYTHON-1064: emit column " << c << " of type " << emitTypeMap.at(colInfo[c].type) << " but data given have type " << colTypes[c].first;
                             throw std::runtime_error(ss.str().c_str());
                         }
                     }
@@ -724,7 +724,7 @@ void emit(PyObject *resultHandler, std::vector<ColumnInfo>& colInfo, PyObject *d
                         default:
                         {
                             std::stringstream ss;
-                            ss << "F-UDF.CL.PY-99: emit column " << c << " of type " << emitTypeMap.at(colInfo[c].type) << " but data given have type " << colTypes[c].first;
+                            ss << "F-UDF.CL.SL.PYTHON-1065: emit column " << c << " of type " << emitTypeMap.at(colInfo[c].type) << " but data given have type " << colTypes[c].first;
                             throw std::runtime_error(ss.str().c_str());
                         }
                     }
@@ -757,7 +757,7 @@ void emit(PyObject *resultHandler, std::vector<ColumnInfo>& colInfo, PyObject *d
                         default:
                         {
                             std::stringstream ss;
-                            ss << "F-UDF.CL.PY-100: emit column " << c << " of type " << emitTypeMap.at(colInfo[c].type) << " but data given have type " << colTypes[c].first;
+                            ss << "F-UDF.CL.SL.PYTHON-1066: emit column " << c << " of type " << emitTypeMap.at(colInfo[c].type) << " but data given have type " << colTypes[c].first;
                             throw std::runtime_error(ss.str().c_str());
                         }
                     }
@@ -786,14 +786,14 @@ void emit(PyObject *resultHandler, std::vector<ColumnInfo>& colInfo, PyObject *d
                         {
                             double value = PyFloat_AsDouble(pyInt.get());
                             if (value < 0 && PyErr_Occurred())
-                                throw std::runtime_error("F-UDF.CL.PY-101: emit() PY_INT: PyFloat_AsDouble error");
+                                throw std::runtime_error("F-UDF.CL.SL.PYTHON-1067: emit() PY_INT: PyFloat_AsDouble error");
                             pyValue.reset(PyFloat_FromDouble(value));
                             break;
                         }
                         default:
                         {
                             std::stringstream ss;
-                            ss << "F-UDF.CL.PY-102: emit column " << c << " of type " << emitTypeMap.at(colInfo[c].type) << " but data given have type " << colTypes[c].first;
+                            ss << "F-UDF.CL.SL.PYTHON-1068: emit column " << c << " of type " << emitTypeMap.at(colInfo[c].type) << " but data given have type " << colTypes[c].first;
                             throw std::runtime_error(ss.str().c_str());
                         }
                     }
@@ -828,7 +828,7 @@ void emit(PyObject *resultHandler, std::vector<ColumnInfo>& colInfo, PyObject *d
                         default:
                         {
                             std::stringstream ss;
-                            ss << "F-UDF.CL.PY-103: emit column " << c << " of type " << emitTypeMap.at(colInfo[c].type) << " but data given have type " << colTypes[c].first;
+                            ss << "F-UDF.CL.SL.PYTHON-1069: emit column " << c << " of type " << emitTypeMap.at(colInfo[c].type) << " but data given have type " << colTypes[c].first;
                             throw std::runtime_error(ss.str().c_str());
                         }
                     }
@@ -860,7 +860,7 @@ void emit(PyObject *resultHandler, std::vector<ColumnInfo>& colInfo, PyObject *d
                         default:
                         {
                             std::stringstream ss;
-                            ss << "F-UDF.CL.PY-104: emit column " << c << " of type " << emitTypeMap.at(colInfo[c].type) << " but data given have type " << colTypes[c].first;
+                            ss << "F-UDF.CL.SL.PYTHON-1070: emit column " << c << " of type " << emitTypeMap.at(colInfo[c].type) << " but data given have type " << colTypes[c].first;
                             throw std::runtime_error(ss.str().c_str());
                         }
                     }
@@ -884,7 +884,7 @@ void emit(PyObject *resultHandler, std::vector<ColumnInfo>& colInfo, PyObject *d
                         default:
                         {
                             std::stringstream ss;
-                            ss << "F-UDF.CL.PY-105: emit column " << c << " of type " << emitTypeMap.at(colInfo[c].type) << " but data given have type " << colTypes[c].first;
+                            ss << "F-UDF.CL.SL.PYTHON-1071: emit column " << c << " of type " << emitTypeMap.at(colInfo[c].type) << " but data given have type " << colTypes[c].first;
                             throw std::runtime_error(ss.str().c_str());
                         }
                     }
@@ -908,7 +908,7 @@ void emit(PyObject *resultHandler, std::vector<ColumnInfo>& colInfo, PyObject *d
                         default:
                         {
                             std::stringstream ss;
-                            ss << "F-UDF.CL.PY-106: emit column " << c << " of type " << emitTypeMap.at(colInfo[c].type) << " but data given have type " << colTypes[c].first;
+                            ss << "F-UDF.CL.SL.PYTHON-1072: emit column " << c << " of type " << emitTypeMap.at(colInfo[c].type) << " but data given have type " << colTypes[c].first;
                             throw std::runtime_error(ss.str().c_str());
                         }
                     }
@@ -922,7 +922,7 @@ void emit(PyObject *resultHandler, std::vector<ColumnInfo>& colInfo, PyObject *d
                 default:
                 {
                     std::stringstream ss;
-                    ss << "F-UDF.CL.PY-107: emit: unexpected type: " << colTypes[c].first;
+                    ss << "F-UDF.CL.SL.PYTHON-1073: emit: unexpected type: " << colTypes[c].first;
                     throw std::runtime_error(ss.str().c_str());
                 }
             }
@@ -932,7 +932,7 @@ void emit(PyObject *resultHandler, std::vector<ColumnInfo>& colInfo, PyObject *d
                 PyErr_Fetch(&ptype, &pvalue, &ptraceback);
                 if (pvalue) {
                     std::stringstream ss;
-                    ss << "F-UDF.CL.PY-108: emit(): Error setting value for row " << r << ", column " << c << ": ";
+                    ss << "F-UDF.CL.SL.PYTHON-1074: emit(): Error setting value for row " << r << ", column " << c << ": ";
                     ss << PyUnicode_AsUTF8(pvalue);
                     throw std::runtime_error(ss.str().c_str());
                 }
@@ -943,7 +943,7 @@ void emit(PyObject *resultHandler, std::vector<ColumnInfo>& colInfo, PyObject *d
                 const char *exMsg = PyUnicode_AsUTF8(pyCheckException.get());
                 if (exMsg) {
                     std::stringstream ss;
-                    ss << "F-UDF.CL.PY-109: emit(): " << exMsg;
+                    ss << "F-UDF.CL.SL.PYTHON-1075: emit(): " << exMsg;
                     throw std::runtime_error(ss.str().c_str());
                 }
             }
@@ -981,7 +981,7 @@ PyObject *getNumpyTypes(PyObject *dataframe)
 
     if (!PyList_Check(pyDtypeValues.get())) {
         std::stringstream ss;
-        ss << "F-UDF.CL.PY-110: DataFrame.dtypes.values is not a list";
+        ss << "F-UDF.CL.SL.PYTHON-1076: DataFrame.dtypes.values is not a list";
         throw std::runtime_error(ss.str().c_str());
     }
 
@@ -1001,7 +1001,7 @@ void getOutputColumnTypes(PyObject *colTypes, std::vector<ColumnInfo>& colInfo)
 {
     if (!PyList_Check(colTypes)) {
         std::stringstream ss;
-        ss << "F-UDF.CL.PY-111: getOutputColumnTypes(): colTypes is not a list";
+        ss << "F-UDF.CL.SL.PYTHON-1077: getOutputColumnTypes(): colTypes is not a list";
         throw std::runtime_error(ss.str().c_str());
     }
 
@@ -1011,7 +1011,7 @@ void getOutputColumnTypes(PyObject *colTypes, std::vector<ColumnInfo>& colInfo)
         checkPyObjectIsNull(pyColType);
         int colType = PyLong_AsLong(pyColType);
         if (colType < 0 && PyErr_Occurred())
-            throw std::runtime_error("F-UDF.CL.PY-112: getColumnInfo(): PyLong_AsLong error");
+            throw std::runtime_error("F-UDF.CL.SL.PYTHON-1078: getColumnInfo(): PyLong_AsLong error");
 
         colInfo.push_back(ColumnInfo(std::to_string(i), colType));
     }
@@ -1034,7 +1034,7 @@ static PyObject *getDataframe(PyObject *self, PyObject *args)
         PyPtr pyInputType(PyObject_GetAttrString(ctxIter, "_exaiter__intype"));
         int inputType = PyLong_AsLong(pyInputType.get());
         if (inputType < 0 && PyErr_Occurred())
-            throw std::runtime_error("F-UDF.CL.PY-113: getDataframe(): PyLong_AsLong error");
+            throw std::runtime_error("F-UDF.CL.SL.PYTHON-1079: getDataframe(): PyLong_AsLong error");
 
         // Get script input type
         bool isSetInput = (static_cast<SWIGVMContainers::SWIGVM_itertype_e>(inputType) == SWIGVMContainers::MULTIPLE);
@@ -1049,7 +1049,7 @@ static PyObject *getDataframe(PyObject *self, PyObject *args)
         if (isFinished) {
             int ok = PyObject_SetAttrString(ctxIter, "_exaiter__finished", Py_True);
             if (ok < 0)
-                throw std::runtime_error("F-UDF.CL.PY-114: getDataframe(): error setting exaiter.__finished");
+                throw std::runtime_error("F-UDF.CL.SL.PYTHON-1080: getDataframe(): error setting exaiter.__finished");
         }
         // Create DataFrame
         pyDataFrame.reset(createDataFrame(pyData.get(), colInfo));

--- a/exaudfclient/base/python/pythoncontainer.cc
+++ b/exaudfclient/base/python/pythoncontainer.cc
@@ -294,7 +294,7 @@ const char* PythonVMImpl::singleCall(single_call_function_id_e fn, const Executi
         }
         if (func == NULL)
         {
-            abort();
+            throw PythonVM::exception("F-UDF.CL.PY-128: Unknown single call function "+fn);
         }
         PyObject* argObject = NULL;
 
@@ -477,7 +477,7 @@ const char* PythonVMImpl::singleCall(single_call_function_id_e fn, const Executi
         } else {
             runobj = PyDict_GetItemString(globals, "__pythonvm_wrapped_singleCall"); check("F-UDF.CL.PY-64");
             if (runobj == NULL) {
-                abort();
+                throw PythonVM::exception("F-UDF.CL.PY-129: Cannot find function __pythonvm_wrapped_singleCall");
             }
             // Call indirectly
             if (argObject == NULL) {

--- a/exaudfclient/base/python/pythoncontainer.cc
+++ b/exaudfclient/base/python/pythoncontainer.cc
@@ -102,7 +102,7 @@ PythonVM::PythonVM(bool checkOnly) {
     } catch (std::exception& err) {
         lock_guard<mutex> lock(exception_msg_mtx);
         DBG_EXCEPTION(cerr, err);
-        exception_msg = "F-UDF.CL.PY-39: " + std::string(err.what());
+        exception_msg = "F-UDF.CL.SL.PYTHON-1000: " + std::string(err.what());
     }
 
 }
@@ -112,7 +112,7 @@ void PythonVM::shutdown() {
        DBG_FUNC_CALL(cerr, m_impl->shutdown());
     } catch (std::exception& err) {
         lock_guard<mutex> lock(exception_msg_mtx);
-        exception_msg = "F-UDF.CL.PY-40: " + std::string(err.what());
+        exception_msg = "F-UDF.CL.SL.PYTHON-1001: " + std::string(err.what());
     }
 }
 
@@ -122,10 +122,10 @@ bool PythonVM::run() {
         return result; 
     } catch (std::exception& err) {
         lock_guard<mutex> lock(exception_msg_mtx);
-        exception_msg = "F-UDF.CL.PY-41: "+ std::string(err.what());
+        exception_msg = "F-UDF.CL.SL.PYTHON-1002: "+ std::string(err.what());
     } catch (...) {
         lock_guard<mutex> lock(exception_msg_mtx);
-        exception_msg = "F-UDF.CL.PY-42: python crashed for unknown reasons";
+        exception_msg = "F-UDF.CL.SL.PYTHON-1003: python crashed for unknown reasons";
     }
     return false;
 }
@@ -136,7 +136,7 @@ const char* PythonVM::singleCall(single_call_function_id_e fn, const ExecutionGr
         return m_impl->singleCall(fn, args,calledUndefinedSingleCall);
     } catch (std::exception& err) {
         lock_guard<mutex> lock(exception_msg_mtx);
-        exception_msg = "F-UDF.CL.PY-43: "+std::string(err.what());
+        exception_msg = "F-UDF.CL.SL.PYTHON-1004: "+std::string(err.what());
     }
     return strdup("<this is an error>");
 }
@@ -177,13 +177,13 @@ PythonVMImpl::PythonVMImpl(bool checkOnly): m_checkOnly(checkOnly)
         
 	globals = PyDict_New();
 	PyDict_SetItemString(globals, "__builtins__", PyEval_GetBuiltins());
-	script = Py_CompileString(script_code.c_str(), SWIGVM_params->script_name, Py_file_input); check("F-UDF.CL.PY-48");
-        if (script == NULL) throw PythonVM::exception("F-UDF.CL.PY-44: Failed to compile script");
+	script = Py_CompileString(script_code.c_str(), SWIGVM_params->script_name, Py_file_input); check("F-UDF.CL.SL.PYTHON-1005");
+        if (script == NULL) throw PythonVM::exception("F-UDF.CL.SL.PYTHON-1006: Failed to compile script");
 
 #ifndef DISABLE_PYTHON_SUBINTERP
         pythread = PyThreadState_New(main_thread->interp);
         if (pythread == NULL)
-            throw PythonVM::exception("F-UDF.CL.PY-45: Failed to create Python interpreter");
+            throw PythonVM::exception("F-UDF.CL.SL.PYTHON-1007: Failed to create Python interpreter");
 #endif
     }
 
@@ -197,34 +197,34 @@ PythonVMImpl::PythonVMImpl(bool checkOnly): m_checkOnly(checkOnly)
 #ifndef ENABLE_PYTHON3
          init_exascript_python();
 #endif
-        code = Py_CompileString(integrated_exascript_python_py, "exascript_python.py", Py_file_input); check("F-UDF.CL.PY-49");
-        if (code == NULL) throw PythonVM::exception("F-UDF.CL.PY-46: Failed to compile internal module");
+        code = Py_CompileString(integrated_exascript_python_py, "exascript_python.py", Py_file_input); check("F-UDF.CL.SL.PYTHON-1008");
+        if (code == NULL) throw PythonVM::exception("F-UDF.CL.SL.PYTHON-1009: Failed to compile internal module");
         exatable = PyImport_ExecCodeModule((char*)"exascript_python", code);
-	check("F-UDF.CL.PY-50");
-	if (exatable == NULL) throw PythonVM::exception("F-UDF.CL.PY-47: Failed to import code module");
+	check("F-UDF.CL.SL.PYTHON-1010");
+	if (exatable == NULL) throw PythonVM::exception("F-UDF.CL.SL.PYTHON-1011: Failed to import code module");
 
-        code = Py_CompileString(integrated_exascript_python_preset_py, "<EXASCRIPTPP>", Py_file_input); check("F-UDF.CL.PY-51");
-        if (code == NULL) {check("F-UDF.CL.PY-52");}
+        code = Py_CompileString(integrated_exascript_python_preset_py, "<EXASCRIPTPP>", Py_file_input); check("F-UDF.CL.SL.PYTHON-1012");
+        if (code == NULL) {check("F-UDF.CL.SL.PYTHON-1013");}
 
  #ifdef ENABLE_PYTHON3
- 	PyEval_EvalCode(code, globals, globals); check("F-UDF.CL.PY-53"); 
+ 	PyEval_EvalCode(code, globals, globals); check("F-UDF.CL.SL.PYTHON-1014"); 
  #else
-	PyEval_EvalCode(reinterpret_cast<PyCodeObject*>(code), globals, globals); check("F-UDF.CL.PY-54");
+	PyEval_EvalCode(reinterpret_cast<PyCodeObject*>(code), globals, globals); check("F-UDF.CL.SL.PYTHON-1015");
  #endif
         Py_DECREF(code);
 
-         PyObject *runobj = PyDict_GetItemString(globals, "__pythonvm_wrapped_parse"); check("F-UDF.CL.PY-55");
+         PyObject *runobj = PyDict_GetItemString(globals, "__pythonvm_wrapped_parse"); check("F-UDF.CL.SL.PYTHON-1016");
          //PyObject *retvalue = PyObject_CallFunction(runobj, NULL); check();
-	 PyObject *retvalue = PyObject_CallFunctionObjArgs(runobj, globals, NULL); check("F-UDF.CL.PY-56");
+	 PyObject *retvalue = PyObject_CallFunctionObjArgs(runobj, globals, NULL); check("F-UDF.CL.SL.PYTHON-1017");
          Py_XDECREF(retvalue); retvalue = NULL;
 
-	code = Py_CompileString(integrated_exascript_python_wrap_py, "<EXASCRIPT>", Py_file_input); check("F-UDF.CL.PY-57");
+	code = Py_CompileString(integrated_exascript_python_wrap_py, "<EXASCRIPT>", Py_file_input); check("F-UDF.CL.SL.PYTHON-1018");
         if (code == NULL) throw PythonVM::exception("Failed to compile wrapping script");
 
 #ifdef ENABLE_PYTHON3
-	PyEval_EvalCode(code, globals, globals); check("F-UDF.CL.PY-58");
+	PyEval_EvalCode(code, globals, globals); check("F-UDF.CL.SL.PYTHON-1019");
 #else
-        PyEval_EvalCode(reinterpret_cast<PyCodeObject*>(code), globals, globals); check("F-UDF.CL.PY-59");
+        PyEval_EvalCode(reinterpret_cast<PyCodeObject*>(code), globals, globals); check("F-UDF.CL.SL.PYTHON-1020");
 #endif
 
         Py_XDECREF(code); 
@@ -241,12 +241,12 @@ void PythonVMImpl::shutdown() {
 #endif
         Py_XDECREF(retvalue);
         if (!m_checkOnly) {
-            cleanobj = PyDict_GetItemString(globals, "cleanup"); check("F-UDF.CL.PY-123");
+            cleanobj = PyDict_GetItemString(globals, "cleanup"); check("F-UDF.CL.SL.PYTHON-1021");
             if (cleanobj){
-                clean_wrap_obj = PyDict_GetItemString(globals, "__pythonvm_wrapped_cleanup"); check("F-UDF.CL.PY-122");
+                clean_wrap_obj = PyDict_GetItemString(globals, "__pythonvm_wrapped_cleanup"); check("F-UDF.CL.SL.PYTHON-1022");
                 if (clean_wrap_obj) {
                     retvalue = PyObject_CallObject(clean_wrap_obj, NULL);
-                    check("F-UDF.CL.PY-60");
+                    check("F-UDF.CL.SL.PYTHON-1023");
                 } 
             }
         }
@@ -260,17 +260,17 @@ void PythonVMImpl::shutdown() {
 bool PythonVMImpl::run() {
     DBG_FUNC_BEGIN( cerr );
 
-    if (m_checkOnly) throw PythonVM::exception("F-UDF.CL.PY-66: Python VM in check only mode");
+    if (m_checkOnly) throw PythonVM::exception("F-UDF.CL.SL.PYTHON-1024: Python VM in check only mode");
 
     {
 #ifndef DISABLE_PYTHON_SUBINTERP
         PythonThreadBlock block;
         PyThreadState_Swap(pythread);
 #endif
-        DBG_FUNC_CALL(cerr, runobj = PyDict_GetItemString(globals, "__pythonvm_wrapped_run")); check("F-UDF.CL.PY-61");
-        DBG_FUNC_CALL(cerr, retvalue = PyObject_CallFunction(runobj, NULL)); check("F-UDF.CL.PY-62");
+        DBG_FUNC_CALL(cerr, runobj = PyDict_GetItemString(globals, "__pythonvm_wrapped_run")); check("F-UDF.CL.SL.PYTHON-1025");
+        DBG_FUNC_CALL(cerr, retvalue = PyObject_CallFunction(runobj, NULL)); check("F-UDF.CL.SL.PYTHON-1026");
 	if (retvalue == NULL) {
-	  throw PythonVM::exception("F-UDF.CL.PY-67: Python VM: calling 'run' failed without an exception)");
+	  throw PythonVM::exception("F-UDF.CL.SL.PYTHON-1027: Python VM: calling 'run' failed without an exception)");
 	}
         Py_XDECREF(retvalue); retvalue = NULL;
     }
@@ -281,7 +281,7 @@ bool PythonVMImpl::run() {
 static string singleCallResult;
 
 const char* PythonVMImpl::singleCall(single_call_function_id_e fn, const ExecutionGraph::ScriptDTO& args , string& calledUndefinedSingleCall) {
-    if (m_checkOnly) throw PythonVM::exception("F-UDF.CL.PY-68: Python VM in check only mode (singleCall)"); // @@@@ TODO: better exception text
+    if (m_checkOnly) throw PythonVM::exception("F-UDF.CL.SL.PYTHON-1028: Python VM in check only mode (singleCall)"); // @@@@ TODO: better exception text
     //{
 #ifndef DISABLE_PYTHON_SUBINTERP
         PythonThreadBlock block;
@@ -298,7 +298,7 @@ const char* PythonVMImpl::singleCall(single_call_function_id_e fn, const Executi
         }
         if (func == NULL)
         {
-            throw PythonVM::exception("F-UDF.CL.PY-128: Unknown single call function "+fn);
+            throw PythonVM::exception("F-UDF.CL.SL.PYTHON-1029: Unknown single call function "+fn);
         }
         PyObject* argObject = NULL;
 
@@ -308,7 +308,7 @@ const char* PythonVMImpl::singleCall(single_call_function_id_e fn, const Executi
             const ExecutionGraph::ImportSpecification* imp_spec = dynamic_cast<const ExecutionGraph::ImportSpecification*>(&args);
             if (imp_spec == NULL)
             {
-                throw PythonVM::exception("F-UDF.CL.PY-69: Internal Python VM error: cannot cast argument DTO to import specification");
+                throw PythonVM::exception("F-UDF.CL.SL.PYTHON-1030: Internal Python VM error: cannot cast argument DTO to import specification");
             }
             //        import_spec.is_subselect
             PyDict_SetItemString(argObject,"is_subselect", (imp_spec->isSubselect())?Py_True:Py_False);
@@ -389,7 +389,7 @@ const char* PythonVMImpl::singleCall(single_call_function_id_e fn, const Executi
             const ExecutionGraph::ExportSpecification* exp_spec = dynamic_cast<const ExecutionGraph::ExportSpecification*>(&args);
             if (exp_spec == NULL)
             {
-                throw PythonVM::exception("F-UDF.CL.PY-70: Internal Python VM error: cannot cast argument DTO to export specification");
+                throw PythonVM::exception("F-UDF.CL.SL.PYTHON-1031: Internal Python VM error: cannot cast argument DTO to export specification");
             }
 
             if (exp_spec->hasConnectionName()) {
@@ -465,7 +465,7 @@ const char* PythonVMImpl::singleCall(single_call_function_id_e fn, const Executi
 
 //        Py_XINCREF(argObject);
 
-        PyObject* funcToCall = PyDict_GetItemString(globals, func); check("F-UDF.CL.PY-120");
+        PyObject* funcToCall = PyDict_GetItemString(globals, func); check("F-UDF.CL.SL.PYTHON-1032");
         if (funcToCall == NULL) {
             calledUndefinedSingleCall = func;
             return strdup("<error>");
@@ -476,12 +476,12 @@ const char* PythonVMImpl::singleCall(single_call_function_id_e fn, const Executi
             // TODO VS This will all be refactored
             const ExecutionGraph::StringDTO* argDto = dynamic_cast<const ExecutionGraph::StringDTO*>(&args);
             string string_arg = argDto->getArg();
-            runobj = PyDict_GetItemString(globals, func); check("F-UDF.CL.PY-63");
+            runobj = PyDict_GetItemString(globals, func); check("F-UDF.CL.SL.PYTHON-1033");
             retvalue = PyObject_CallFunction(runobj, (char *)"s", string_arg.c_str());
         } else {
-            runobj = PyDict_GetItemString(globals, "__pythonvm_wrapped_singleCall"); check("F-UDF.CL.PY-64");
+            runobj = PyDict_GetItemString(globals, "__pythonvm_wrapped_singleCall"); check("F-UDF.CL.SL.PYTHON-1034");
             if (runobj == NULL) {
-                throw PythonVM::exception("F-UDF.CL.PY-129: Cannot find function __pythonvm_wrapped_singleCall");
+                throw PythonVM::exception("F-UDF.CL.SL.PYTHON-1035: Cannot find function __pythonvm_wrapped_singleCall");
             }
             // Call indirectly
             if (argObject == NULL) {
@@ -490,14 +490,14 @@ const char* PythonVMImpl::singleCall(single_call_function_id_e fn, const Executi
                 retvalue = PyObject_CallFunctionObjArgs(runobj, funcToCall, argObject, NULL);
             }
         }
-        check("F-UDF.CL.PY-65");
+        check("F-UDF.CL.SL.PYTHON-1036");
 
         Py_XDECREF(argObject);
 
         if (!PyString_Check(retvalue) && !PyUnicode_Check(retvalue))
         {
             std::stringstream sb;
-            sb << "F-UDF.CL.PY-71: ";
+            sb << "F-UDF.CL.SL.PYTHON-1037: ";
             sb << fn;
             sb << " did not return string type (singleCall)";
             throw PythonVM::exception(sb.str().c_str());

--- a/exaudfclient/base/python/pythoncontainer.cc
+++ b/exaudfclient/base/python/pythoncontainer.cc
@@ -461,7 +461,7 @@ const char* PythonVMImpl::singleCall(single_call_function_id_e fn, const Executi
 
 //        Py_XINCREF(argObject);
 
-        PyObject* funcToCall = PyDict_GetItemString(globals, func); check("F-UDF.CL.PY-62");
+        PyObject* funcToCall = PyDict_GetItemString(globals, func); check("F-UDF.CL.PY-120");
         if (funcToCall == NULL) {
             calledUndefinedSingleCall = func;
             return strdup("<error>");

--- a/exaudfclient/base/python/pythoncontainer.cc
+++ b/exaudfclient/base/python/pythoncontainer.cc
@@ -33,6 +33,8 @@ static void check(const std::string& error_code) {
     PyErr_Fetch(&pt, &pv, &tb); if (pt == NULL) return;
     PyErr_NormalizeException(&pt, &pv, &tb); if (pt == NULL) return;
     s = PyObject_Str(pv);
+    
+    // Get Exception name
     if (NULL != (pvc = PyObject_GetAttrString(pv, "__class__"))) {
         if (NULL != (pvcn = PyObject_GetAttrString(pvc, "__name__"))) {
 #ifdef ENABLE_PYTHON3
@@ -48,6 +50,8 @@ static void check(const std::string& error_code) {
         }
         Py_XDECREF(pvc);
     }
+
+
     string exception_string("");
 #ifdef ENABLE_PYTHON3
     PyObject* repr = PyObject_Str(s);

--- a/find_duplicate_error_codes.sh
+++ b/find_duplicate_error_codes.sh
@@ -1,11 +1,9 @@
-
-
 #!/bin/bash
 set -o errexit
 set -o nounset
 set -o pipefail
 
-DUPLICATES=$(bash find_error_codes.sh | cut -f 1,2,3 -d "-" --output-delimiter " " | sort -k2 -k 3n | uniq -D -f 1 | cut -f 1,2,3 -d " " --output-delimiter "-")
+DUPLICATES=$(bash find_error_codes.sh | IFS="-"  uniq -D -f 1)
 if [ -z "$DUPLICATES" ]
 then
   echo "No duplicated error codes found"

--- a/find_error_codes.sh
+++ b/find_error_codes.sh
@@ -3,4 +3,4 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-grep --only-matching --exclude=error_codes.yml --exclude-dir=.build_output --exclude-dir=script-languages -I  --line-number -R -E "[FEW]-[A-Z]+(\.[A-Z]+)*-[0-9]+" | sed -E "s/^(.+:[0-9]+):(.*)/\1\t\2/g" | sort --field-separator "-" --key=2,2 --key=3,3n 
+grep --only-matching --exclude=error_codes.yml --exclude-dir=bazel*  --exclude-dir=.build_output --exclude-dir=script-languages -I  --line-number -R -E "[FEW]-[A-Z]+(\.[A-Z]+)*-[0-9]+" | sed -E "s/^(.+:[0-9]+):(.*)/\1\t\2/g" | sort --field-separator "-" --key=2,2 --key=3,3n 

--- a/find_error_codes.sh
+++ b/find_error_codes.sh
@@ -3,4 +3,4 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-grep --exclude-dir=.build_output -I  --line-number -R -E "[FEW]-[A-Z]+(\.[A-Z]+)*-[0-9]+" | sed -E "s/^(.*:[0-9]+):.*([FEW]-[A-Z]+(\.[A-Z]+)*-[0-9]+).*$/\1\t\2/g" | sort --field-separator "-" --key=2,2 --key=3,3n 
+grep --only-matching --exclude=error_codes.yml --exclude-dir=.build_output --exclude-dir=script-languages -I  --line-number -R -E "[FEW]-[A-Z]+(\.[A-Z]+)*-[0-9]+" | sed -E "s/^(.+:[0-9]+):(.*)/\1\t\2/g" | sort --field-separator "-" --key=2,2 --key=3,3n 

--- a/find_error_codes.sh
+++ b/find_error_codes.sh
@@ -3,4 +3,4 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-grep -I  --line-number -R -E "[FEW]-[A-Z]+(\.[A-Z]+)*-[0-9]+" | sed -E "s/^(.*:[0-9]+):.*([FEW]-[A-Z]+(\.[A-Z]+)*-[0-9]+).*$/\1\t\2/g"
+grep --exclude-dir=.build_output -I  --line-number -R -E "[FEW]-[A-Z]+(\.[A-Z]+)*-[0-9]+" | sed -E "s/^(.*:[0-9]+):.*([FEW]-[A-Z]+(\.[A-Z]+)*-[0-9]+).*$/\1\t\2/g" | sort --field-separator "-" --key=2,2 --key=3,3n 

--- a/find_highest_error_codes_per_module.sh
+++ b/find_highest_error_codes_per_module.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+bash find_error_codes.sh | cut -f 2,3 -d "-" | awk '$2 > a[$1] { a[$1] = $2 } END {for( k in a) print k "," a[k]}' FS=-

--- a/find_next_error_code_per_module.sh
+++ b/find_next_error_code_per_module.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+set -o errexit
+set -o nounset
+set -o pipefail
+
+error_codes=$(bash find_error_codes.sh | cut -f 2)
+highest_error_codes_per_module=$(bash find_highest_error_codes_per_module.sh)
+
+for highest_error_code_for_module in $highest_error_codes_per_module
+do
+  module=$(echo $highest_error_code_for_module | cut -f 1 -d ",")
+  highest_error_code=$(echo $highest_error_code_for_module | cut -f 2 -d ",")
+#  echo module: $module
+#  echo highest_error_code: $highest_error_code
+  error_codes_for_module=$(echo $error_codes | tr " " "\n" | cut -f 2,3 -d "-" | grep "$module" | cut -f 2)
+  miss_algined_error_code=$(echo "$error_codes_for_module" | tr " " "\n" | cut -f 2 -d "-" | awk 'BEGIN{ line=1 } { if ($1 != line) { print $1; exit } ; line++}')
+  if [ -n "$miss_algined_error_code" ]
+  then
+    echo $module-$((miss_algined_error_code-1))
+  else
+    echo $module-$((highest_error_code+1))
+  fi
+done

--- a/find_next_error_code_per_module.sh
+++ b/find_next_error_code_per_module.sh
@@ -3,7 +3,7 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-error_codes=$(bash find_error_codes.sh | cut -f 2)
+error_codes=$(bash find_error_codes.sh | cut -f 2 | uniq) # uniq is needed in case of duplicates, because the awk to find the miss_algined_error_code fails on duplicates
 highest_error_codes_per_module=$(bash find_highest_error_codes_per_module.sh)
 
 for highest_error_code_for_module in $highest_error_codes_per_module
@@ -13,7 +13,7 @@ do
 #  echo module: $module
 #  echo highest_error_code: $highest_error_code
   error_codes_for_module=$(echo $error_codes | tr " " "\n" | cut -f 2,3 -d "-" | grep "$module" | cut -f 2)
-  miss_algined_error_code=$(echo "$error_codes_for_module" | tr " " "\n" | cut -f 2 -d "-" | awk 'BEGIN{ line=1 } { if ($1 != line) { print $1; exit } ; line++}')
+  miss_algined_error_code=$(echo "$error_codes_for_module" | tr " " "\n" | cut -f 2 -d "-" | awk 'BEGIN{ line=1 } { if ($1 != line) { print $1; exit } ; line++}') # we assume find_error_codes.sh returns the error codes sorted by their module and number
   if [ -n "$miss_algined_error_code" ]
   then
     echo $module-$((miss_algined_error_code-1))

--- a/find_next_error_code_per_module.sh
+++ b/find_next_error_code_per_module.sh
@@ -14,6 +14,7 @@ do
 #  echo highest_error_code: $highest_error_code
   error_codes_for_module=$(echo $error_codes | tr " " "\n" | cut -f 2,3 -d "-" | grep "$module" | cut -f 2)
   miss_algined_error_code=$(echo "$error_codes_for_module" | tr " " "\n" | cut -f 2 -d "-" | awk 'BEGIN{ line=1 } { if ($1 != line) { print $1; exit } ; line++}') # we assume find_error_codes.sh returns the error codes sorted by their module and number
+  # echo "$error_codes_for_module" | tr " " "\n" | cut -f 2 -d "-" | awk 'BEGIN{ line=1 } { print $1 "," line ; line++}' # DEBUG Allgnment
   if [ -n "$miss_algined_error_code" ]
   then
     echo $module-$((miss_algined_error_code-1))

--- a/find_next_error_code_per_module.sh
+++ b/find_next_error_code_per_module.sh
@@ -13,7 +13,7 @@ do
 #  echo module: $module
 #  echo highest_error_code: $highest_error_code
   error_codes_for_module=$(echo $error_codes | tr " " "\n" | cut -f 2,3 -d "-" | grep "$module" | cut -f 2)
-  miss_algined_error_code=$(echo "$error_codes_for_module" | tr " " "\n" | cut -f 2 -d "-" | awk 'BEGIN{ line=1 } { if ($1 != line) { print $1; exit } ; line++}') # we assume find_error_codes.sh returns the error codes sorted by their module and number
+  miss_algined_error_code=$(echo "$error_codes_for_module" | tr " " "\n" | cut -f 2 -d "-" | awk 'BEGIN{ line=1000 } { if ($1 != line) { print $1; exit } ; line++}') # we assume find_error_codes.sh returns the error codes sorted by their module and number
   # echo "$error_codes_for_module" | tr " " "\n" | cut -f 2 -d "-" | awk 'BEGIN{ line=1 } { print $1 "," line ; line++}' # DEBUG Allgnment
   if [ -n "$miss_algined_error_code" ]
   then

--- a/githooks/install.sh
+++ b/githooks/install.sh
@@ -26,6 +26,10 @@ copy_hook() {
     local RELATIVE_PATH=$(realpath --relative-to="$GITHOOKS_PATH" "$SCRIPT_PATH")
     echo $RELATIVE_PATH
     pushd "$GITHOOKS_PATH"
+    if [ -f "$2" ]
+    then
+      rm "$2"
+    fi
     ln -s "$RELATIVE_PATH" "$2"
     chmod +x "$2"
     popd

--- a/githooks/pre-commit
+++ b/githooks/pre-commit
@@ -1,28 +1,12 @@
 #!/bin/bash
-# define colors for use in output
-green='\033[0;32m'
-no_color='\033[0m'
-grey='\033[0;90m'
+set -o errexit
+set -o nounset
+set -o pipefail
 
-# Check whether any submodule is about to be updated with the
-# commit. Ask the user for confirmation.
-# --Chaitanya Gupta
-
-echo -e "Checking submodules ${grey}(pre-commit hook)${no_color} "
-
-# Jump to the current project's root directory (the one containing
-# .git/)
-ROOT_DIR=$(git rev-parse --show-cdup)
-
-SUBMODULES=$(grep path ${ROOT_DIR}.gitmodules | sed 's/^.*path = //' | sort)
-
-CURRENT_GITMODULES="$ROOT_DIR.current_gitmodules"
-if [ -f "$CURRENT_GITMODULES" ]
-then
-  rm "$CURRENT_GITMODULES"
-fi
-for SUB in $SUBMODULES
-do
-    git ls-files -s "$SUB" >> "$CURRENT_GITMODULES"
-done
-git add "$CURRENT_GITMODULES"
+REPO_DIR=$(git rev-parse --show-toplevel)
+GITHOOKS_PATH="$REPO_DIR/githooks"
+pushd $REPO_DIR
+bash $GITHOOKS_PATH/update_current_submodules_file.sh
+echo "Searching for duplicated error codes in repository (pre-commit hook)"
+bash find_duplicate_error_codes.sh
+popd

--- a/githooks/update_current_submodules_file.sh
+++ b/githooks/update_current_submodules_file.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+set -o errexit
+set -o nounset
+set -o pipefail
+
+# define colors for use in output
+green='\033[0;32m'
+no_color='\033[0m'
+grey='\033[0;90m'
+
+echo -e "Checking submodules ${grey}(pre-commit hook)${no_color} "
+
+# Jump to the current project's root directory (the one containing
+# .git/)
+ROOT_DIR=$(git rev-parse --show-cdup)
+
+SUBMODULES=$(grep path ${ROOT_DIR}.gitmodules | sed 's/^.*path = //' | sort)
+
+CURRENT_GITMODULES="$ROOT_DIR.current_gitmodules"
+if [ -f "$CURRENT_GITMODULES" ]
+then
+  rm "$CURRENT_GITMODULES"
+fi
+for SUB in $SUBMODULES
+do
+    git ls-files -s "$SUB" >> "$CURRENT_GITMODULES"
+done
+git add "$CURRENT_GITMODULES"


### PR DESCRIPTION
- Return full but compact stack traces for user code exceptions in Java and Python UDFs
  - Java stack traces now contain also causes of Exceptions
  - Verbose stack frames inside the language implementations get still cleaned to make the exceptions easier to read
- Error codes now start at number 1000 (see https://softwareengineering.stackexchange.com/questions/209693/best-practices-to-create-error-codes-pattern-for-an-enterprise-project-in-c)
- Add error codes to the language implementations for Java, Python and R in the UDFClient
- Add missing error codes to exaudflib
- Introduce new name schema for error codes in exaudflib of the form [FEW]-UDF.CL.LIB-1000
- Add precommit githook which searches for duplicated error codes
- Replace abort()-calls in the language implementations with exceptions 