### PR TITLE
Pin tensorflow_hub version for python3-ds flavors and add local githooks to protect master

### DIFF
--- a/flavors/python3-ds-EXASOL-6.0.0/flavor_base/flavor_base_deps/packages/pip3_packages
+++ b/flavors/python3-ds-EXASOL-6.0.0/flavor_base/flavor_base_deps/packages/pip3_packages
@@ -1,7 +1,7 @@
 pyexasol
 keras
 tensorflow==1.13.1
-tensorflow-hub
+tensorflow-hub==0.4.0
 kmodes
 seaborn
 matplotlib

--- a/flavors/python3-ds-EXASOL-6.1.0/flavor_base/flavor_base_deps/packages/pip3_packages
+++ b/flavors/python3-ds-EXASOL-6.1.0/flavor_base/flavor_base_deps/packages/pip3_packages
@@ -1,7 +1,7 @@
 pyexasol
 keras
 tensorflow==1.13.1
-tensorflow-hub
+tensorflow-hub==0.4.0
 kmodes
 seaborn
 matplotlib

--- a/githooks/install.sh
+++ b/githooks/install.sh
@@ -10,30 +10,36 @@ GIT_DIR="$REPO_DIR/.git"
 if [[ ! -d "$GIT_DIR" ]]; then
   if [[ -d "$REPO_DIR/../.git" ]]; then
     GIT_DIR="$REPO_DIR/../.git"
-    GITHOOKS_PATH="$GIT_DIR/modules/script-languages/hooks/"
+    GITHOOKS_PATH="$GIT_DIR/modules/script-languages/hooks"
   else
     echo "$GIT_DIR is not a git directory." >&2
     exit 1
   fi
 else
-    GITHOOKS_PATH="$GIT_DIR/hooks/"
+    GITHOOKS_PATH="$GIT_DIR/hooks"
 fi
 
 copy_hook() {
     local SCRIPT_PATH="$SCRIPT_DIR/$1"
     local GITHOOK_PATH="$GITHOOKS_PATH/$2"
-    echo "Link $GITHOOK_PATH to $SCRIPT_PATH" >&2
     local RELATIVE_PATH=$(realpath --relative-to="$GITHOOKS_PATH" "$SCRIPT_PATH")
-    echo $RELATIVE_PATH
-    pushd "$GITHOOKS_PATH"
-    if [ -f "$2" ]
+    pushd "$GITHOOKS_PATH" > /dev/null
+    if [ -e "$GITHOOK_PATH" ] || [ -L "$GITHOOK_PATH" ]
     then
-      rm "$2"
+      echo
+      echo "Going to delete old hook $GITHOOK_PATH"
+      rm "$GITHOOK_PATH" > /dev/null
     fi
-    ln -s "$RELATIVE_PATH" "$2"
-    chmod +x "$2"
-    popd
+    echo
+    echo "Link hook to script" >&2
+    echo "Hook-Path: $GITHOOK_PATH" >&2
+    echo "Script-path: $SCRIPT_PATH" >&2
+    echo
+    ln -s "$RELATIVE_PATH" "$2" > /dev/null
+    chmod +x "$SCRIPT_PATH" > /dev/null
+    popd > /dev/null
 }
 
 copy_hook pre-commit pre-commit
 copy_hook pre-commit post-rewrite
+copy_hook pre-push pre-push

--- a/githooks/install_recursive.sh
+++ b/githooks/install_recursive.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+set -o errexit
+set -o nounset
+set -o pipefail
+
+SCRIPT_DIR="$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")"
+REPO_DIR=$(git rev-parse --show-toplevel)
+
+echo
+echo "Install hook for $REPO_DIR"
+echo "=================================================================="
+echo
+bash "$REPO_DIR/githooks/install.sh"
+echo
+
+submodule_paths=$(git submodule status --recursive | sed "s/^\s*//" | cut -f 2 -d " ")
+for submodule_path in $submodule_paths
+do
+    echo
+    echo "Install hook for submodule $REPO_DIR/$submodule_path"
+    echo "==============================================================="
+    echo
+    install_script_for_submodule="$REPO_DIR/$submodule_path/githooks/install.sh"
+    if [[ -f "$install_script_for_submodule" ]]
+    then
+        bash "$install_script_for_submodule"
+    fi
+    echo
+done

--- a/githooks/pre-commit
+++ b/githooks/pre-commit
@@ -5,8 +5,9 @@ set -o pipefail
 
 REPO_DIR=$(git rev-parse --show-toplevel)
 GITHOOKS_PATH="$REPO_DIR/githooks"
-pushd $REPO_DIR
-bash $GITHOOKS_PATH/update_current_submodules_file.sh
+pushd "$REPO_DIR"
+bash "$GITHOOKS_PATH/prohibit_commit_to_master.sh"
 echo "Searching for duplicated error codes in repository (pre-commit hook)"
 bash find_duplicate_error_codes.sh
+bash "$GITHOOKS_PATH/update_current_submodules_file.sh"
 popd

--- a/githooks/pre-push
+++ b/githooks/pre-push
@@ -1,0 +1,43 @@
+#!/bin/bash
+protected_branches=( master )
+for i in "${protected_branches[@]}"
+do
+
+    protected_branch=$i
+
+    policy='[Policy] Never push, force push or delete the '$protected_branch' branch! (Prevented with pre-push hook.)'
+
+    current_branch=$(git symbolic-ref HEAD | sed -e 's,.*/\(.*\),\1,')
+
+    push_command=$(ps -ocommand= -p $PPID)
+
+    is_destructive='force|delete|\-f'
+
+    will_remove_protected_branch=':'$protected_branch
+
+    do_exit(){
+      echo $policy
+      exit 1
+    }
+
+    if [[ $push_command =~ $is_destructive ]] && [ $current_branch = $protected_branch ]; then
+      do_exit
+    fi
+
+    if [[ $push_command =~ $is_destructive ]] && [[ $push_command =~ $protected_branch ]]; then
+      do_exit
+    fi
+
+    if [[ $push_command =~ $will_remove_protected_branch ]]; then
+      do_exit
+    fi
+
+    if [[ $protected_branch == $current_branch ]]; then
+      do_exit
+    fi
+
+done
+
+unset do_exit
+
+exit 0

--- a/githooks/prohibit_commit_to_master.sh
+++ b/githooks/prohibit_commit_to_master.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+
+branch="$(git rev-parse --abbrev-ref HEAD)"
+
+if [ "$branch" = "master" ]; then
+  echo "You can't commit directly to master branch"
+  exit 1
+fi

--- a/google-cloud-build/download_config.sh
+++ b/google-cloud-build/download_config.sh
@@ -7,6 +7,6 @@ env_file=".env/env.yaml"
 SCRIPT_DIR="$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")"
 PROJECT=$1
 CONFIG_BUCKET_NAME=$2
-CONFIG_BUCKET="gs://$CONFIG_BUCKET_NAME/.env"
+CONFIG_BUCKET="gs://$CONFIG_BUCKET_NAME/*"
 gcloud config set project "$PROJECT"
-gsutil -m cp -r "$CONFIG_BUCKET" "file://." 
+gsutil -m cp -r "$CONFIG_BUCKET" "file://.env" 


### PR DESCRIPTION
- Pin tensorflow_hub version for python3-ds flavors, because newer versions are incompatible with tensorflow 1.13.1
- Add local githooks to protect master branch
- Fix path in google-cloud-build/download_config.sh