### PR TITLE
Fix missing cleanup call if run fails in Java-UDFs

### DIFF
--- a/exaudfclient/base/build_local_all.sh
+++ b/exaudfclient/base/build_local_all.sh
@@ -1,1 +1,1 @@
-bash build_local.sh $* --config no-tty --config python --config java
+bash build_local.sh $* --config no-tty --config python --config java --config slow-wrapper-py3

--- a/exaudfclient/base/javacontainer/javacontainer.cc
+++ b/exaudfclient/base/javacontainer/javacontainer.cc
@@ -122,6 +122,19 @@ JavaVMImpl::JavaVMImpl(bool checkOnly): m_checkOnly(checkOnly), m_exaJavaPath(""
 }
 
 void JavaVMImpl::shutdown() {
+    if (m_checkOnly)
+        throwException("F-UDF.CL.SL.JAVA-1159: Java VM in check only mode");
+    jclass cls = m_env->FindClass("com/exasol/ExaWrapper");
+    string calledUndefinedSingleCall;
+    check("F-UDF.CL.SL.JAVA-1160",calledUndefinedSingleCall);
+    if (!cls)
+        throwException("F-UDF.CL.SL.JAVA-1161: FindClass for ExaWrapper failed");
+    jmethodID mid = m_env->GetStaticMethodID(cls, "cleanup", "()V");
+    check("F-UDF.CL.SL.JAVA-1162",calledUndefinedSingleCall);
+    if (!mid)
+        throwException("F-UDF.CL.SL.JAVA-1163: GetStaticMethodID for run failed");
+    m_env->CallStaticVoidMethod(cls, mid);
+    check("F-UDF.CL.SL.JAVA-1164",calledUndefinedSingleCall);
     try {
         m_jvm->DestroyJavaVM();
     } catch(...) { 

--- a/tests/lib/exatest/clients/odbc.py
+++ b/tests/lib/exatest/clients/odbc.py
@@ -4,6 +4,13 @@ import pyodbc
 class ClientError(Exception):
     pass
 
+def getScriptLanguagesFromArgs():
+    for i, arg in enumerate(sys.argv):
+        if arg == '--script-languages':
+            if len(sys.argv) == i + 1:
+                raise ClientError('Value for --script-languages missing')
+            return sys.argv[i + 1]
+
 class ODBCClient(object):
     def __init__(self, dsn, user="sys", password="exasol"):
         self.cursor = None
@@ -26,7 +33,8 @@ class ODBCClient(object):
             if arg == '--script-languages':
                 if len(sys.argv) == i + 1:
                     raise ClientError('Value for --script-languages missing')
-                self.query("ALTER SESSION SET SCRIPT_LANGUAGES='%s'" % sys.argv[i + 1])
+                langs=getScriptLanguagesFromArgs()
+                self.query("ALTER SESSION SET SCRIPT_LANGUAGES='%s'" % langs)
                 break
 
     def query(self, qtext, *args):

--- a/tests/test/java/general.py
+++ b/tests/test/java/general.py
@@ -122,8 +122,8 @@ class JavaInterpreter(udf.TestCase):
             foo()
             RETURNS INT AS
             class FOO {
-                static int run(ExaMetadata exa, ExaIterator ctx) {
-                    throw new Exception("42);
+                static int run(ExaMetadata exa, ExaIterator ctx) throws Exception {
+                    throw new Exception("42");
                 }
                 static int cleanup(ExaMetadata exa) throws Exception {
                     throw new Exception("4711");

--- a/tests/test/python/general.py
+++ b/tests/test/python/general.py
@@ -79,12 +79,12 @@ class PythonInterpreter(udf.TestCase):
             RETURNS INT AS
 
             def run(ctx):
-                raise ValueError('42')
+                raise ValueError('XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX.')
 
             def cleanup():
-                raise ValueError('4711')
+                raise ValueError('YYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYY')
             '''))
-        with self.assertRaisesRegexp(Exception, '42.*4711'):
+        with self.assertRaisesRegexp(Exception, 'XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX.*YYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYY'):
             self.query('SELECT foo() FROM dual')
 
     def test_cleanup_has_global_context(self):


### PR DESCRIPTION
- The cleanup call in the Java UDF was in the same method as the run call. If the run call failed it bailed out of the method with an exception and didn't call cleanup.
- We extracted the cleanup part of the method into it own method and call this from the C++ as the protocol it demands
- For the test that cleanup is called after run fails, we could not use pyodbc, because it truncates the error messages. As such, we added query_via_exaplus to the test lib and used it to execute the query with exaplus.