### PR TITLE
Handle multiple lines at once in LogHandlers

### DIFF
--- a/.current_gitmodules
+++ b/.current_gitmodules
@@ -1,1 +1,1 @@
-160000 c96dbb0fe241b11eb4b87e065336a2f13fe0ec16 0	exaslct_src/test_environment
+160000 d9920d431d31bb2ac2d9c5dd8dd2967f9ab82a0b 0	exaslct_src/test_environment

--- a/.current_gitmodules
+++ b/.current_gitmodules
@@ -1,1 +1,1 @@
-160000 d9920d431d31bb2ac2d9c5dd8dd2967f9ab82a0b 0	exaslct_src/test_environment
+160000 73b649af25ac19dffb6ef7119cf57c51d16ebe19 0	exaslct_src/test_environment

--- a/exaslct_src/exaslct/lib/tasks/export/export_container_base_task.py
+++ b/exaslct_src/exaslct/lib/tasks/export/export_container_base_task.py
@@ -153,10 +153,10 @@ class ExportContainerBaseTask(FlavorBaseTask):
             with CommandLogHandler(log_file_path, self.logger, description) as log_handler:
                 still_running_logger = StillRunningLogger(
                     self.logger, description)
-                log_handler.handle_log_line((command + "\n").encode("utf-8"))
+                log_handler.handle_log_lines((command + "\n").encode("utf-8"))
                 for line in iter(process.stdout.readline, b''):
                     still_running_logger.log()
-                    log_handler.handle_log_line(line)
+                    log_handler.handle_log_lines(line)
                 process.wait(timeout=60 * 2)
                 return_code_log_line = "return code %s" % process.returncode
-                log_handler.handle_log_line(return_code_log_line.encode("utf-8"), process.returncode != 0)
+                log_handler.handle_log_lines(return_code_log_line.encode("utf-8"), process.returncode != 0)


### PR DESCRIPTION
Docker on MacOSX seems to return multiple lines at once when streaming API call logs. This patch extends the API of all LogHandlers with the function handle_log_lines to accept multiple lines. The AbstractLogHandler does the decoding and splitting of the lines and feeds them into the method handle_log_line.
The DockerRegistryImageChecker used before its own method to parse the log, it now uses a specific implementation of the LogHandler which simplifies this step.