### PR TITLE
Fix generate-language-activation for standard-EXASOL-7.0.0

### DIFF
--- a/exaslct_src/exaslct/lib/tasks/test/test_runner_db_test_task.py
+++ b/exaslct_src/exaslct/lib/tasks/test/test_runner_db_test_task.py
@@ -108,7 +108,8 @@ class TestRunnerDBTestTask(FlavorBaseTask,
             flavor_path=self.flavor_path,
             bucket_name="myudfs",
             bucketfs_name="bfsdefault",
-            path_in_bucket="")
+            path_in_bucket="",
+            add_missing_builtin = True)
         task = self.create_child_task_with_common_params(
             RunDBTestsInTestConfig,
             test_environment_info=test_environment_info,

--- a/exaslct_src/exaslct/lib/tasks/test/test_runner_db_test_task.py
+++ b/exaslct_src/exaslct/lib/tasks/test/test_runner_db_test_task.py
@@ -16,6 +16,7 @@ from exaslct_src.test_environment.src.lib.data.environment_type import Environme
 from exaslct_src.test_environment.src.lib.test_environment.spawn_test_environment import SpawnTestEnvironment
 from exaslct_src.test_environment.src.lib.test_environment.spawn_test_environment_parameter import \
     SpawnTestEnvironmentParameter
+from exaslct_src.exaslct.lib.tasks.upload.language_definition import LanguageDefinition
 
 
 class TestRunnerDBTestTask(FlavorBaseTask,
@@ -40,9 +41,11 @@ class TestRunnerDBTestTask(FlavorBaseTask,
 
     def register_export_container(self):
         export_container_task = self.create_child_task(ExportFlavorContainer,
-                                                       release_goals=[self.release_goal],
+                                                       release_goals=[
+                                                           self.release_goal],
                                                        flavor_path=self.flavor_path)
-        self._export_infos_future = self.register_dependency(export_container_task)
+        self._export_infos_future = self.register_dependency(
+            export_container_task)
 
     def register_spawn_test_environment(self):
         test_environment_name = f"""{self.get_flavor_name()}_{self.release_goal}"""
@@ -50,21 +53,23 @@ class TestRunnerDBTestTask(FlavorBaseTask,
             self.create_child_task_with_common_params(
                 SpawnTestEnvironment,
                 environment_name=test_environment_name)
-        self._test_environment_info_future = self.register_dependency(spawn_test_environment_task)
+        self._test_environment_info_future = self.register_dependency(
+            spawn_test_environment_task)
 
     def run_task(self):
-        export_infos = self.get_values_from_future(self._export_infos_future)  # type: Dict[str,ExportInfo]
+        export_infos = self.get_values_from_future(
+            self._export_infos_future)  # type: Dict[str,ExportInfo]
         export_info = export_infos[self.release_goal]
         self.test_environment_info = self.get_values_from_future(
             self._test_environment_info_future)  # type: EnvironmentInfo
         reuse_release_container = self.reuse_database and \
-                                  self.reuse_uploaded_container and \
-                                  not export_info.is_new
+            self.reuse_uploaded_container and \
+            not export_info.is_new
         database_credentials = self.get_database_credentials()
         yield from self.upload_container(database_credentials,
                                          export_info,
                                          reuse_release_container)
-        test_results = yield from self.run_test(self.test_environment_info)
+        test_results = yield from self.run_test(self.test_environment_info, export_info)
         self.return_object(test_results)
 
     def upload_container(self, database_credentials, export_info, reuse_release_container):
@@ -91,24 +96,32 @@ class TestRunnerDBTestTask(FlavorBaseTask,
                                     db_password=SpawnTestEnvironment.DEFAULT_DATABASE_PASSWORD,
                                     bucketfs_write_password=SpawnTestEnvironment.DEFAULT_BUCKETFS_WRITE_PASSWORD)
 
-    def run_test(self, test_environment_info: EnvironmentInfo) -> \
+    def run_test(self, test_environment_info: EnvironmentInfo, export_info:ExportInfo) -> \
             Generator[RunDBTestsInTestConfig, Any, RunDBTestsInTestConfigResult]:
         test_config = self.read_test_config()
         generic_language_tests = self.get_generic_language_tests(test_config)
         test_folders = self.get_test_folders(test_config)
         database_credentials = self.get_database_credentials()
+        # "myudfs/containers/" + self.export_info.name + ".tar.gz"
+        language_definition = LanguageDefinition(
+            release_name=export_info.name,
+            flavor_path=self.flavor_path,
+            bucket_name="myudfs",
+            bucketfs_name="bfsdefault",
+            path_in_bucket="")
         task = self.create_child_task_with_common_params(
             RunDBTestsInTestConfig,
             test_environment_info=test_environment_info,
             generic_language_tests=generic_language_tests,
             test_folders=test_folders,
-            language_definition=test_config["language_definition"],
+            language_definition=language_definition.generate_definition(),
             db_user=database_credentials.db_user,
             db_password=database_credentials.db_password,
             bucketfs_write_password=database_credentials.bucketfs_write_password
         )
         test_output_future = yield from self.run_dependencies(task)
-        test_output = self.get_values_from_future(test_output_future)  # type: RunDBTestsInTestConfigResult
+        test_output = self.get_values_from_future(
+            test_output_future)  # type: RunDBTestsInTestConfigResult
         return test_output
 
     def get_result_status(self, status):
@@ -130,13 +143,14 @@ class TestRunnerDBTestTask(FlavorBaseTask,
 
     def tests_specified_in_parameters(self):
         return len(self.generic_language_tests) != 0 or \
-               len(self.test_folders) != 0 or \
-               len(self.test_files) != 0
+            len(self.test_folders) != 0 or \
+            len(self.test_files) != 0
 
     def get_generic_language_tests(self, test_config):
         generic_language_tests = []
         if test_config["generic_language_tests"] != "":
-            generic_language_tests = test_config["generic_language_tests"].split(" ")
+            generic_language_tests = test_config["generic_language_tests"].split(
+                " ")
         if self.tests_specified_in_parameters():
             generic_language_tests = self.generic_language_tests
         return generic_language_tests

--- a/exaslct_src/exaslct/lib/tasks/upload/language_definition.py
+++ b/exaslct_src/exaslct/lib/tasks/upload/language_definition.py
@@ -9,18 +9,21 @@ class LanguageDefinition():
                  flavor_path: str,
                  bucketfs_name: str,
                  bucket_name: str,
-                 path_in_bucket: str):
+                 path_in_bucket: str,
+                 add_missing_builtin: bool = False):
         self.path_in_bucket = path_in_bucket
         self.bucket_name = bucket_name
         self.bucketfs_name = bucketfs_name
         self.flavor_path = flavor_path
         self.release_name = release_name
+        self.add_missing_builtin = add_missing_builtin
 
     def generate_definition(self):
-        path_in_bucket=self.path_in_bucket
-        if path_in_bucket != "" and  not path_in_bucket.endswith("/"):
-            path_in_bucket=path_in_bucket+"/"
-        language_definition_path = Path(self.flavor_path, "flavor_base", "language_definition")
+        path_in_bucket = self.path_in_bucket
+        if path_in_bucket != "" and not path_in_bucket.endswith("/"):
+            path_in_bucket = path_in_bucket+"/"
+        language_definition_path = Path(
+            self.flavor_path, "flavor_base", "language_definition")
         with language_definition_path.open("r") as f:
             language_definition_template = f.read()
         template = Template(language_definition_template)
@@ -28,7 +31,16 @@ class LanguageDefinition():
                                               bucket_name=self.bucket_name,
                                               path_in_bucket=path_in_bucket,
                                               release_name=self.release_name)
-        return language_definition
+        if self.add_missing_builtin:
+            defined_aliases = [alias.split("=")[0]
+                               for alias in language_definition.split(" ")]
+            builtin_aliases = ["PYTHON", "JAVA", "R"]
+            missing_aliases = set(builtin_aliases) - set(defined_aliases)
+            additional_language_defintions = " ".join(
+                alias+"=builtin_"+alias.lower() for alias in missing_aliases)
+            language_definition = " ".join(
+                [language_definition, additional_language_defintions])
+        return language_definition.strip()
 
     def generate_alter_session(self):
         return f"""ALTER SESSION SET SCRIPT_LANGUAGES='{self.generate_definition()}';"""

--- a/exaslct_src/test/resources/test-flavor/flavor_base/language_definition
+++ b/exaslct_src/test/resources/test-flavor/flavor_base/language_definition
@@ -1,1 +1,1 @@
-PYTHON=localzmq+protobuf:///{{ bucketfs_name }}/{{ bucket_name }}/{{ path_in_bucket }}{{ release_name }}?lang=python#buckets/{{ bucketfs_name }}/{{ bucket_name }}/{{ path_in_bucket }}{{ release_name }}/exaudf/exaudfclient
+PYTHON3=localzmq+protobuf:///{{ bucketfs_name }}/{{ bucket_name }}/{{ path_in_bucket }}{{ release_name }}?lang=python#buckets/{{ bucketfs_name }}/{{ bucket_name }}/{{ path_in_bucket }}{{ release_name }}/exaudf/exaudfclient_py3

--- a/exaslct_src/test/resources/test-flavor/flavor_base/testconfig
+++ b/exaslct_src/test/resources/test-flavor/flavor_base/testconfig
@@ -1,4 +1,3 @@
-language_definition=PYTHON3=localzmq+protobuf:///bfsdefault/myudfs/test-flavor?lang=python#exaudf/exaudfclient_py3 JAVA=builtin_java R=builtin_r PYTHON=builtin_python
 generic_language_tests=
 test_folders=selftest
 # ending new line required!

--- a/exaslct_src/test/test_generate_language_activation.py
+++ b/exaslct_src/test/test_generate_language_activation.py
@@ -12,13 +12,13 @@ class GenerateLanguageActivationTest(unittest.TestCase):
     def test_generate_with_path_in_bucket(self):
         command = f"./exaslct generate-language-activation --bucketfs-name bfsdefault --bucket-name default --path-in-bucket path --container-name container"
         completed_process=self.test_environment.run_command(command,use_docker_repository=False, use_output_directory=False, capture_output=True)
-        self.assertIn("ALTER SESSION SET SCRIPT_LANGUAGES='PYTHON=localzmq+protobuf:///bfsdefault/default/path/container?lang=python#buckets/bfsdefault/default/path/container/exaudf/exaudfclient';",completed_process.stdout.decode("UTF-8"))
+        self.assertIn("ALTER SESSION SET SCRIPT_LANGUAGES='PYTHON3=localzmq+protobuf:///bfsdefault/default/path/container?lang=python#buckets/bfsdefault/default/path/container/exaudf/exaudfclient_py3';",completed_process.stdout.decode("UTF-8"))
 
 
     def test_generate_without_path_in_bucket(self):
         command = f"./exaslct generate-language-activation --bucketfs-name bfsdefault --bucket-name default --container-name container"
         completed_process=self.test_environment.run_command(command,use_docker_repository=False, use_output_directory=False, capture_output=True)
-        self.assertIn("ALTER SESSION SET SCRIPT_LANGUAGES='PYTHON=localzmq+protobuf:///bfsdefault/default/container?lang=python#buckets/bfsdefault/default/container/exaudf/exaudfclient';",completed_process.stdout.decode("UTF-8"))
+        self.assertIn("ALTER SESSION SET SCRIPT_LANGUAGES='PYTHON3=localzmq+protobuf:///bfsdefault/default/container?lang=python#buckets/bfsdefault/default/container/exaudf/exaudfclient_py3';",completed_process.stdout.decode("UTF-8"))
 
 if __name__ == '__main__':
     unittest.main()

--- a/flavors/python3-ds-EXASOL-6.0.0/flavor_base/testconfig
+++ b/flavors/python3-ds-EXASOL-6.0.0/flavor_base/testconfig
@@ -1,3 +1,2 @@
-language_definition=PYTHON3=localzmq+protobuf:///bfsdefault/myudfs/python3-ds-EXASOL-6.0.0?lang=python#exaudf/exaudfclient_py3 JAVA=builtin_java R=builtin_r PYTHON=builtin_python
 generic_language_tests=python3
 test_folders=python3 python3-ds-flavor

--- a/flavors/python3-ds-EXASOL-6.1.0/flavor_base/testconfig
+++ b/flavors/python3-ds-EXASOL-6.1.0/flavor_base/testconfig
@@ -1,3 +1,2 @@
-language_definition=PYTHON3=localzmq+protobuf:///bfsdefault/myudfs/python3-ds-EXASOL-6.1.0?lang=python#exaudf/exaudfclient_py3 JAVA=builtin_java R=builtin_r PYTHON=builtin_python
 generic_language_tests=python3
 test_folders=python3 python3-ds-flavor

--- a/flavors/python3-ds-cuda-preview-EXASOL-6.1.0/flavor_base/testconfig
+++ b/flavors/python3-ds-cuda-preview-EXASOL-6.1.0/flavor_base/testconfig
@@ -1,3 +1,2 @@
-language_definition=PYTHON3=localzmq+protobuf:///bfsdefault/myudfs/python3-ds-cuda-preview-EXASOL-6.1.0?lang=python#exaudf/exaudfclient_py3 JAVA=builtin_java R=builtin_r PYTHON=builtin_python
 generic_language_tests=python3
 test_folders=python3 python3-ds-flavor


### PR DESCRIPTION
- Additionally, incorporate the LanguageDefinition class into the run-db-tests to tests the generation with the flavors together and avoid regressions
- LanguageDefinition class can now add missing builtin language aliases

Fixes https://github.com/exasol/script-languages-release/issues/83