### PR TITLE
Add lists for actual installed packages to the release build step of the flavors

### DIFF
--- a/flavors/python3-ds-EXASOL-6.0.0/flavor_base/release/Dockerfile
+++ b/flavors/python3-ds-EXASOL-6.0.0/flavor_base/release/Dockerfile
@@ -21,3 +21,7 @@ RUN ldconfig
 
 COPY --from={{build_run}} /exaudf /exaudf
 COPY --from={{build_run}} /build_info /build_info
+
+RUN mkdir -p /build_info/actual_installed_packages/release && \
+    /scripts/list_installed_scripts/list_installed_apt.sh > /build_info/actual_installed_packages/release/apt_get_packages && \
+    /scripts/list_installed_scripts/list_installed_pip.sh python3.6 > /build_info/actual_installed_packages/release/python3_pip_packages

--- a/flavors/python3-ds-EXASOL-6.0.0/flavor_base/release/Dockerfile
+++ b/flavors/python3-ds-EXASOL-6.0.0/flavor_base/release/Dockerfile
@@ -8,6 +8,7 @@ COPY --from={{language_deps}} /opt /opt
 COPY --from={{language_deps}} /etc /etc
 COPY --from={{language_deps}} /build_info /build_info
 COPY --from={{language_deps}} /var /var
+COPY --from={{language_deps}} /scripts /scripts
 
 COPY --from={{flavor_customization}} /usr /usr
 COPY --from={{flavor_customization}} /lib /lib

--- a/flavors/python3-ds-EXASOL-6.1.0/flavor_base/release/Dockerfile
+++ b/flavors/python3-ds-EXASOL-6.1.0/flavor_base/release/Dockerfile
@@ -21,3 +21,7 @@ RUN ldconfig
 
 COPY --from={{build_run}} /exaudf /exaudf
 COPY --from={{build_run}} /build_info /build_info
+
+RUN mkdir -p /build_info/actual_installed_packages/release && \
+    /scripts/list_installed_scripts/list_installed_apt.sh > /build_info/actual_installed_packages/release/apt_get_packages && \
+    /scripts/list_installed_scripts/list_installed_pip.sh python3.6 > /build_info/actual_installed_packages/release/python3_pip_packages

--- a/flavors/python3-ds-EXASOL-6.1.0/flavor_base/release/Dockerfile
+++ b/flavors/python3-ds-EXASOL-6.1.0/flavor_base/release/Dockerfile
@@ -8,6 +8,7 @@ COPY --from={{language_deps}} /opt /opt
 COPY --from={{language_deps}} /etc /etc
 COPY --from={{language_deps}} /build_info /build_info
 COPY --from={{language_deps}} /var /var
+COPY --from={{language_deps}} /scripts /scripts
 
 COPY --from={{flavor_customization}} /usr /usr
 COPY --from={{flavor_customization}} /lib /lib

--- a/flavors/python3-ds-cuda-preview-EXASOL-6.1.0/flavor_base/release/Dockerfile
+++ b/flavors/python3-ds-cuda-preview-EXASOL-6.1.0/flavor_base/release/Dockerfile
@@ -21,3 +21,7 @@ RUN ldconfig
 
 COPY --from={{build_run}} /exaudf /exaudf
 COPY --from={{build_run}} /build_info /build_info
+
+RUN mkdir -p /build_info/actual_installed_packages/release && \
+    /scripts/list_installed_scripts/list_installed_apt.sh > /build_info/actual_installed_packages/release/apt_get_packages && \
+    /scripts/list_installed_scripts/list_installed_pip.sh python3.6 > /build_info/actual_installed_packages/release/python3_pip_packages

--- a/flavors/python3-ds-cuda-preview-EXASOL-6.1.0/flavor_base/release/Dockerfile
+++ b/flavors/python3-ds-cuda-preview-EXASOL-6.1.0/flavor_base/release/Dockerfile
@@ -8,6 +8,7 @@ COPY --from={{language_deps}} /opt /opt
 COPY --from={{language_deps}} /etc /etc
 COPY --from={{language_deps}} /build_info /build_info
 COPY --from={{language_deps}} /var /var
+COPY --from={{language_deps}} /scripts /scripts
 
 COPY --from={{flavor_customization}} /usr /usr
 COPY --from={{flavor_customization}} /lib /lib


### PR DESCRIPTION
- The package lists get stored under `/build_info/actual_installed_packages/release`

Contributes to https://github.com/exasol/script-languages-release/issues/92