### PR TITLE
Add NGA default uid to the passwd of the flavors

### DIFF
--- a/exaslct_src/test/test_docker_export.py
+++ b/exaslct_src/test/test_docker_export.py
@@ -3,6 +3,7 @@ import unittest
 
 from exaslct_src.test_environment.src.test import utils
 
+
 class DockerExportTest(unittest.TestCase):
     def setUp(self):
         print(f"SetUp {self.__class__.__name__}")
@@ -17,12 +18,12 @@ class DockerExportTest(unittest.TestCase):
             print(e)
 
     def test_docker_export(self):
-        command=f"./exaslct export --export-path {self.export_path}"
-        self.test_environment.run_command(command,track_task_dependencies=True)
+        command = f"./exaslct export --export-path {self.export_path}"
+        self.test_environment.run_command(command, track_task_dependencies=True)
         exported_files = os.listdir(self.export_path)
-        self.assertEqual(list(exported_files),['test-flavor_release.tar.gz', 'test-flavor_release.tar.gz.checksum'],
-                        f"Did not found saved files for repository {self.test_environment.repository_name} "
-                        f"in list {exported_files}")
+        self.assertEqual(sorted(list(exported_files)), sorted(['test-flavor_release.tar.gz', 'test-flavor_release.tar.gz.checksum']),
+                         f"Did not found saved files for repository {self.test_environment.repository_name} "
+                         f"in list {exported_files}")
 
 
 if __name__ == '__main__':

--- a/flavors/python3-ds-EXASOL-6.0.0/flavor_base/udfclient_deps/Dockerfile
+++ b/flavors/python3-ds-EXASOL-6.0.0/flavor_base/udfclient_deps/Dockerfile
@@ -19,6 +19,8 @@ RUN apt-get -y update && \
 
 RUN addgroup --gid 1000 exasolution
 RUN adduser --disabled-login --uid 1000 --gid 1000 exasolution --gecos "First Last,RoomNumber,WorkPhone,HomePhone"
+RUN addgroup --gid 500 exausers 
+RUN adduser --disabled-login --uid 500 --gid 500 exadefusr --gecos "First Last,RoomNumber,WorkPhone,HomePhone"
 
 ENV LANG en_US.UTF-8
 ENV LANGUAGE en_US:en

--- a/flavors/python3-ds-EXASOL-6.1.0/flavor_base/udfclient_deps/Dockerfile
+++ b/flavors/python3-ds-EXASOL-6.1.0/flavor_base/udfclient_deps/Dockerfile
@@ -14,6 +14,8 @@ RUN /scripts/install_scripts/install_via_apt.pl --file /build_info/packages/udfc
 
 RUN addgroup --gid 1000 exasolution
 RUN adduser --disabled-login --uid 1000 --gid 1000 exasolution --gecos "First Last,RoomNumber,WorkPhone,HomePhone"
+RUN addgroup --gid 500 exausers 
+RUN adduser --disabled-login --uid 500 --gid 500 exadefusr --gecos "First Last,RoomNumber,WorkPhone,HomePhone"
 
 ENV LANG en_US.UTF-8
 ENV LANGUAGE en_US:en

--- a/flavors/python3-ds-cuda-preview-EXASOL-6.1.0/flavor_base/udfclient_deps/Dockerfile
+++ b/flavors/python3-ds-cuda-preview-EXASOL-6.1.0/flavor_base/udfclient_deps/Dockerfile
@@ -21,6 +21,8 @@ RUN apt-get update && \
 
 RUN addgroup --gid 1000 exasolution
 RUN adduser --disabled-login --uid 1000 --gid 1000 exasolution --gecos "First Last,RoomNumber,WorkPhone,HomePhone"
+RUN addgroup --gid 500 exausers 
+RUN adduser --disabled-login --uid 500 --gid 500 exadefusr --gecos "First Last,RoomNumber,WorkPhone,HomePhone"
 
 ENV LANG en_US.UTF-8
 ENV LANGUAGE en_US:en

--- a/tests/test/python/getpass.py
+++ b/tests/test/python/getpass.py
@@ -18,7 +18,7 @@ class GetpassTest(udf.TestCase):
 
     def test_getuser(self):
         self.query(udf.fixindent('''
-                CREATE OR REPLACE python3 SCALAR SCRIPT
+                CREATE OR REPLACE python SCALAR SCRIPT
                 get_user_from_passwd()
                 RETURNS VARCHAR(10000) AS
 

--- a/tests/test/python/getpass.py
+++ b/tests/test/python/getpass.py
@@ -1,0 +1,39 @@
+#!/usr/bin/env python2.7
+
+import os
+import sys
+
+sys.path.append(os.path.realpath(__file__ + '/../../../lib'))
+
+import udf
+from udf import useData, expectedFailure
+
+class GetpassTest(udf.TestCase):
+    def setUp(self):
+        self.query('CREATE SCHEMA getpass', ignore_errors=True)
+        self.query('OPEN SCHEMA getpass', ignore_errors=True)
+
+    def tearDown(self):
+        self.query('DROP SCHEMA getpass CASCADE', ignore_errors=True)
+
+    def test_getuser(self):
+        self.query(udf.fixindent('''
+                CREATE OR REPLACE python3 SCALAR SCRIPT
+                get_user_from_passwd()
+                RETURNS VARCHAR(10000) AS
+
+                def run(ctx):
+                    import getpass
+                    return getpass.getuser()
+                /
+                '''))
+        rows = self.query("select get_user_from_passwd()")
+        expected = u"exadefusr"
+        self.assertEqual(expected ,rows[0][0])
+
+
+if __name__ == '__main__':
+    udf.main()
+
+# vim: ts=4:sts=4:sw=4:et:fdm=indent
+

--- a/tests/test/python3/getpass.py
+++ b/tests/test/python3/getpass.py
@@ -1,0 +1,39 @@
+#!/usr/bin/env python2.7
+
+import os
+import sys
+
+sys.path.append(os.path.realpath(__file__ + '/../../../lib'))
+
+import udf
+from udf import useData, expectedFailure
+
+class GetpassTest(udf.TestCase):
+    def setUp(self):
+        self.query('CREATE SCHEMA getpass', ignore_errors=True)
+        self.query('OPEN SCHEMA getpass', ignore_errors=True)
+
+    def tearDown(self):
+        self.query('DROP SCHEMA getpass CASCADE', ignore_errors=True)
+
+    def test_getuser(self):
+        self.query(udf.fixindent('''
+                CREATE OR REPLACE python3 SCALAR SCRIPT
+                get_user_from_passwd()
+                RETURNS VARCHAR(10000) AS
+
+                def run(ctx):
+                    import getpass
+                    return getpass.getuser()
+                /
+                '''))
+        rows = self.query("select get_user_from_passwd()")
+        expected = u"exadefusr"
+        self.assertEqual(expected ,rows[0][0])
+
+
+if __name__ == '__main__':
+    udf.main()
+
+# vim: ts=4:sts=4:sw=4:et:fdm=indent
+


### PR DESCRIPTION
- Add test for getpass.getuser for python and python3 UDFs
- Furthermore, fix unstable list comparison in exaslct_src/test/test_docker_export.py 

Related to https://github.com/exasol/script-languages-release/issues/116