### PR TITLE
Use legacy resolver for pip in install_via_pip.pl

### DIFF
--- a/ext/scripts/install_scripts/install_via_pip.pl
+++ b/ext/scripts/install_scripts/install_via_pip.pl
@@ -51,7 +51,7 @@ if($python_binary eq ''){
 }
 
 my $element_separator = '\\|';
-my $combining_template = "$python_binary -m pip install --ignore-installed --no-cache-dir <<<<0>>>>";
+my $combining_template = "$python_binary -m pip install --use-deprecated=legacy-resolver --ignore-installed --no-cache-dir <<<<0>>>>";
 my @templates = ("'<<<<0>>>>'");
 if($with_versions){
     @templates=("'<<<<0>>>>==<<<<1>>>>'")


### PR DESCRIPTION
We add the option --use-deprecated=legacy-resolver to install_via_pip.pl to enable the legacy dependency resolver to get our flavors temporarily working again with pip 20.3. Until pip 21.0, we need to change the python dependencies in a way to fix all conflicts, see https://github.com/exasol/script-languages-release/issues/150.