### PR TITLE
 Fix the exit code of the exaslct start script

### DIFF
--- a/exaslct
+++ b/exaslct
@@ -12,6 +12,7 @@ source pipenv_utils.sh
 
 run () {
     export PYTHONPATH="$SCRIPT_DIR"
+    set -o pipefail # this is necessary to get the exit code of the python script instead of the tee command
     $PIPENV_BIN run python3 "$SCRIPT_DIR/exaslct_src/exaslct.py" $COMMAND_LINE_ARGS 2>&1 | tee exaslct.log
     exit $?
 }

--- a/exaslct
+++ b/exaslct
@@ -13,6 +13,7 @@ source pipenv_utils.sh
 run () {
     export PYTHONPATH="$SCRIPT_DIR"
     $PIPENV_BIN run python3 "$SCRIPT_DIR/exaslct_src/exaslct.py" $COMMAND_LINE_ARGS 2>&1 | tee exaslct.log
+    exit $?
 }
 
 discover_pipenv

--- a/google-cloud-build/ci-scripts/scripts/build.sh
+++ b/google-cloud-build/ci-scripts/scripts/build.sh
@@ -20,6 +20,11 @@ COMMAND="./exaslct build --flavor-path "flavors/$FLAVOR" $BUILD_PARAMETER $ADDIT
 echo "Executing Command: $COMMAND"
 $COMMAND || echo "fail" >> /workspace/build-status.txt
 echo
+
+echo "/workspace/build-status.txt"
+cat /workspace/build-status.txt
+echo
+
 COMMAND="./exaslct build-test-container $ADDITIONAL_ARGUMENTS $SYSTEM_PARAMETER"
 echo "Executing Command: $COMMAND"
 $COMMAND || echo "fail" >> /workspace/build-status.txt

--- a/google-cloud-build/ci-scripts/scripts/build.sh
+++ b/google-cloud-build/ci-scripts/scripts/build.sh
@@ -23,6 +23,10 @@ echo
 COMMAND="./exaslct build-test-container $ADDITIONAL_ARGUMENTS $SYSTEM_PARAMETER"
 echo "Executing Command: $COMMAND"
 $COMMAND || echo "fail" >> /workspace/build-status.txt
+
+echo "/workspace/build-status.txt"
+cat /workspace/build-status.txt 
+
 echo
 echo "=========================================================="
 echo "Printing docker images"

--- a/google-cloud-build/ci-scripts/scripts/check_build.sh
+++ b/google-cloud-build/ci-scripts/scripts/check_build.sh
@@ -25,6 +25,11 @@ echo "Copy rsync.log to $BUCKET/rsync.log"
 echo "=========================================================="
 echo
 gsutil cp rync.log "$BUCKET"
+
+echo "/workspace/build-status.txt"
+cat /workspace/build-status.txt 
+echo
+
 if grep fail /workspace/build-status.txt
 then
 	exit 1


### PR DESCRIPTION
 The exit code of the python script was hidden by the pipe to tee. I added `set -o pipefail` before running the python script to get the exit code of the failing command in the pipe.

Part of https://github.com/exasol/script-languages-release/issues/167