### PR TITLE
Fix url for get-pip.py in install_python2.7_pip.sh

### DIFF
--- a/ext/scripts/install_scripts/install_python2.7_pip.sh
+++ b/ext/scripts/install_scripts/install_python2.7_pip.sh
@@ -2,6 +2,6 @@
 
 set -euo pipefail
 
-curl -o get-pip.py https://bootstrap.pypa.io/2.7/get-pip.py
+curl -o get-pip.py https://bootstrap.pypa.io/pip/2.7/get-pip.py
 python2.7 get-pip.py "pip < 21"
 rm get-pip.py


### PR DESCRIPTION
The download url for get-pip.py changed and needed to be changed.

Closes https://github.com/exasol/script-languages-release/issues/201