### PR TITLE
#264: Fixed broken link in flavor description

### DIFF
--- a/flavors/python-3.6-minimal-EXASOL-6.2.0/FLAVOR_DESCRIPTION.md
+++ b/flavors/python-3.6-minimal-EXASOL-6.2.0/FLAVOR_DESCRIPTION.md
@@ -8,7 +8,7 @@
 - [Language dependencies](flavor_base/language_deps/packages/apt_get_packages)
 - Flavor packages
   - [Ubuntu packages](flavor_base/flavor_base_deps/packages/apt_get_packages)
-  - [Python3 pip packages](flavor_base/flavor_base_deps/packages/pip3_packages)
+  - [Python3 pip packages](flavor_base/flavor_base_deps/packages/python3_pip_packages)
 - Customization
   - [Ubuntu packages](flavor_customization/packages/apt_get_packages)
   - [Python3 pip packages](flavor_customization/packages/python3_pip_packages)


### PR DESCRIPTION
 Fixed broken link in flavor description of Python-3.6-minimal-EXASOL-6.2.0