### PR TITLE
#284 Added test for verification of removal of Python2

### DIFF
--- a/tests/test/python3-no-python2/verify_python2.py
+++ b/tests/test/python3-no-python2/verify_python2.py
@@ -13,37 +13,42 @@ class NoPython2(udf.TestCase):
         self.query('create schema no_python2', ignore_errors=True)
 
     def test_no_python2_bin(self):
-        got_exception = False
         self.query(udf.fixindent('''
             CREATE OR REPLACE PYTHON3 SCALAR SCRIPT no_python2.test_python2_bin_not_available() returns int AS
             import subprocess
             import os.path
             def run(ctx): 
-                assert os.path.isdir("/usr/bin/python2") == False
-                subprocess.run(["python2", "--version"])
-                return 1
+                retVal = 1 if os.path.isdir("/usr/bin/python2") else 0
+                try:
+                    subprocess.run(["python2", "--version"])
+                    retVal += 1
+                except:
+                    pass
+                    
+                return retVal
             /
             '''))
         try:
-            self.query('''SELECT no_python2.test_python2_bin_not_available() FROM dual''')
+            rows = self.query('''SELECT no_python2.test_python2_bin_not_available() FROM dual''')
+            self.assertRowsEqual([(0,)], rows)
         except:
-            got_exception = True
-        assert got_exception
+            print("Error executing test 'test_no_python2_bin'")
+            raise
 
     def test_no_python2_lib(self):
         self.query(udf.fixindent('''
             CREATE OR REPLACE PYTHON3 SCALAR SCRIPT no_python2.test_python2_lib_not_available() returns varchar(10000) AS
             import subprocess
             def run(ctx): 
-                res = subprocess.run(["find", "/", "-name", "libpython2*.so"], stdout=subprocess.PIPE)
+                res = subprocess.run(["find", "/", "-name", "libpython2*.so", 
+                    "!", "-path", "/buckets/*", 
+                    "!", "-path", "/tmp/*"], stdout=subprocess.PIPE)
                 return res.stdout.decode("utf-8")  #If there are no libraries installed, find should return empty string
             /
             '''))
         try:
-
             rows = self.query('''SELECT no_python2.test_python2_lib_not_available() FROM dual''')
-            print("Res Python2 test:" + str(rows[0]))
-            self.assertRowsEqual([('',)], rows)
+            self.assertRowsEqual([(None,)], rows)
         except:
             print("Error executing test 'test_no_python2_lib'")
             raise

--- a/tests/test/python3-no-python2/verify_python2.py
+++ b/tests/test/python3-no-python2/verify_python2.py
@@ -33,7 +33,7 @@ class NoPython2(udf.TestCase):
             self.assertRowsEqual([(0,)], rows)
         except:
             print("Error executing test 'test_no_python2_bin'")
-            pass
+            raise
 
     def test_no_python2_lib(self):
         self.query(udf.fixindent('''
@@ -51,7 +51,7 @@ class NoPython2(udf.TestCase):
             self.assertRowsEqual([(None,)], rows)
         except:
             print("Error executing test 'test_no_python2_lib'")
-            pass
+            raise
 
 
 if __name__ == '__main__':

--- a/tests/test/python3-no-python2/verify_python2.py
+++ b/tests/test/python3-no-python2/verify_python2.py
@@ -33,7 +33,7 @@ class NoPython2(udf.TestCase):
             self.assertRowsEqual([(0,)], rows)
         except:
             print("Error executing test 'test_no_python2_bin'")
-            raise
+            pass
 
     def test_no_python2_lib(self):
         self.query(udf.fixindent('''
@@ -51,7 +51,7 @@ class NoPython2(udf.TestCase):
             self.assertRowsEqual([(None,)], rows)
         except:
             print("Error executing test 'test_no_python2_lib'")
-            raise
+            pass
 
 
 if __name__ == '__main__':

--- a/tests/test/python3-no-python2/verify_python2.py
+++ b/tests/test/python3-no-python2/verify_python2.py
@@ -1,0 +1,53 @@
+#!/usr/bin/env python2.7
+
+import os
+import sys
+
+sys.path.append(os.path.realpath(__file__ + '/../../../lib'))
+
+import udf
+
+
+class NoPython2(udf.TestCase):
+    def setUp(self):
+        self.query('create schema no_python2', ignore_errors=True)
+
+    def test_no_python2_bin(self):
+        got_exception = False
+        self.query(udf.fixindent('''
+            CREATE OR REPLACE PYTHON3 SCALAR SCRIPT no_python2.test_python2_bin_not_available() returns int AS
+            import subprocess
+            import os.path
+            def run(ctx): 
+                assert os.path.isdir("/usr/bin/python2") == False
+                subprocess.run(["python2", "--version"])
+                return 1
+            /
+            '''))
+        try:
+            self.query('''SELECT no_python2.test_python2_bin_not_available() FROM dual''')
+        except:
+            got_exception = True
+        assert got_exception
+
+    def test_no_python2_lib(self):
+        self.query(udf.fixindent('''
+            CREATE OR REPLACE PYTHON3 SCALAR SCRIPT no_python2.test_python2_lib_not_available() returns varchar(10000) AS
+            import subprocess
+            def run(ctx): 
+                res = subprocess.run(["find", "/", "-name", "libpython2*.so"], stdout=subprocess.PIPE)
+                return res.stdout.decode("utf-8")  #If there are no libraries installed, find should return empty string
+            /
+            '''))
+        try:
+
+            rows = self.query('''SELECT no_python2.test_python2_lib_not_available() FROM dual''')
+            print("Res Python2 test:" + str(rows[0]))
+            self.assertRowsEqual([('',)], rows)
+        except:
+            print("Error executing test 'test_no_python2_lib'")
+            raise
+
+
+if __name__ == '__main__':
+    udf.main()


### PR DESCRIPTION
Returns:
```
(u'/buckets/bfsdefault/default/EXAClusterOS/ScriptLanguages-standard-exasol-7.0.0-20201109/usr/lib/python2.7/config-x86_64-linux-gnu/libpython2.7.so\n/buckets/bfsdefault/default/EXAClusterOS/ScriptLanguages-standard-exasol-7.0.0-20201109/usr/lib/x86_64-linux-gnu/libpython2.7.so\n/buckets/bfsdefault/default/EXAClusterOS/ScriptLanguages-standard-exasol-7.0.0-20201109/exaudf/_solib_k8/_U@python2_S_S_Cpython2___Uexternal_Spython2_Susr_Slib_Spython2.7_Sconfig-x86_U64-linux-gnu/libpython2.7.so\n',)
```
I am confused. This looks like it comes from the test spawn environment. But shouldn't 
```
./exaslct run-db-test ...
```
test the current flavor?
@tkilias please help!

Addendum: I assume this is the standard flavor of the docker db, however in run-db-test we upload another bucket, so there exist two different buckets, one with the fresh flavor to be tested, and the default bucket which comes with the database.
