### PR TITLE
#293: Removed unused package from from python-3.6-minimal-EXASOL-6.2.0 flavor

### DIFF
--- a/flavors/python-3.6-minimal-EXASOL-6.2.0/flavor_base/language_deps/packages/apt_get_packages
+++ b/flavors/python-3.6-minimal-EXASOL-6.2.0/flavor_base/language_deps/packages/apt_get_packages
@@ -1,4 +1,3 @@
 python3-dev|3.6.7-1~18.04
-python-distutils-extra|2.41ubuntu1
 python3-distutils|3.6.9-1~18.04
 curl|7.58.0-2ubuntu3.14


### PR DESCRIPTION
Removed python-distutils-extra package from python-3.6-minimal-EXASOL-6.2.0 flavor