### PR TITLE
#362: Update ca-certificates package.

### DIFF
--- a/flavors/python-3.6-data-science-EXASOL-6.2.0/flavor_base/language_deps/packages/apt_get_packages
+++ b/flavors/python-3.6-data-science-EXASOL-6.2.0/flavor_base/language_deps/packages/apt_get_packages
@@ -1,4 +1,4 @@
-ca-certificates|20210119~18.04.1
+ca-certificates|20210119~18.04.2
 python3-distutils|3.6.9-1~18.04
 python3.6|3.6.9-1~18.04ubuntu1.4
 python3.6-dev|3.6.9-1~18.04ubuntu1.4

--- a/flavors/python-3.6-minimal-EXASOL-6.2.0/flavor_base/language_deps/packages/apt_get_packages
+++ b/flavors/python-3.6-minimal-EXASOL-6.2.0/flavor_base/language_deps/packages/apt_get_packages
@@ -1,4 +1,4 @@
-ca-certificates|20210119~18.04.1
+ca-certificates|20210119~18.04.2
 python3-dev|3.6.7-1~18.04
 python3-distutils|3.6.9-1~18.04
 curl|7.58.0-2ubuntu3.16


### PR DESCRIPTION
We are using currently version 2021011918.04.1, but the version in the Ubuntu repositories has jumped to 2021011918.04.2.