### PR TITLE
#395: Avoid creating wheel cache in install_via_pip

### DIFF
--- a/ext/scripts/install_scripts/install_python2.7_pip.sh
+++ b/ext/scripts/install_scripts/install_python2.7_pip.sh
@@ -5,3 +5,4 @@ set -euo pipefail
 curl -o get-pip.py https://bootstrap.pypa.io/pip/2.7/get-pip.py
 python2.7 get-pip.py "pip < 21"
 rm get-pip.py
+rm -rf $(python2.7 -m pip cache dir)

--- a/ext/scripts/install_scripts/install_python3.6_pip.sh
+++ b/ext/scripts/install_scripts/install_python3.6_pip.sh
@@ -5,3 +5,4 @@ set -euo pipefail
 curl -o get-pip.py https://bootstrap.pypa.io/get-pip.py
 python3.6 get-pip.py "pip < 21"
 rm get-pip.py
+rm -rf $(python3.6 -m pip cache dir)

--- a/ext/scripts/install_scripts/install_python3.7_pip.sh
+++ b/ext/scripts/install_scripts/install_python3.7_pip.sh
@@ -5,3 +5,4 @@ set -euo pipefail
 curl -o get-pip.py https://bootstrap.pypa.io/get-pip.py
 python3.7 get-pip.py "pip < 21"
 rm get-pip.py
+rm -rf $(python3.7 -m pip cache dir)

--- a/ext/scripts/install_scripts/install_python3.8_pip.sh
+++ b/ext/scripts/install_scripts/install_python3.8_pip.sh
@@ -5,3 +5,4 @@ set -euo pipefail
 curl -o get-pip.py https://bootstrap.pypa.io/get-pip.py
 python3.8 get-pip.py "pip < 21"
 rm get-pip.py
+rm -rf $(python3.8 -m pip cache dir)

--- a/ext/scripts/list_installed_scripts/list_installed_pip.sh
+++ b/ext/scripts/list_installed_scripts/list_installed_pip.sh
@@ -6,7 +6,7 @@ set -o pipefail
 
 if [[ "$1" =~ .*python.* ]]
 then
-  $1 -m pip list --format columns | tail -n +3 | sed "s/  */|/" | sort -f -d
+  $1 -m pip list --format columns --no-cache-dir | tail -n +3 | sed "s/  */|/" | sort -f -d
 else
   echo "'$1' not a python binary"
   exit 1


### PR DESCRIPTION
RCA:
1. pip install with --no-cache-dir works, no cache is beeing created
2. pip installation itself creates already a cache dir with 2 packages: 'http' and 'selfcheck'
3. "pip list" also creates a pip cache

Solution:
1. Remove cache directory after pip installation (No option was found to suppress creation of cache directory during pip installation)
2. Apply no-cache-dir for pip list