### PR TITLE
#562: Ignored CVE-2022-27191

### DIFF
--- a/flavors/python-3.6-data-science-cuda-EXASOL-6.2.0/flavor_base/security_scan/.trivyignore
+++ b/flavors/python-3.6-data-science-cuda-EXASOL-6.2.0/flavor_base/security_scan/.trivyignore
@@ -6,3 +6,5 @@ CVE-2022-0778
 CVE-2022-1015
 #CVE-2022-23648 is a bug in containerd, not issue for containers
 CVE-2022-23648
+# CVE-2022-27191 is an issue in Go. Which will be installed only together with Trivy.
+CVE-2022-27191

--- a/flavors/python-3.6-minimal-EXASOL-6.2.0/flavor_base/security_scan/.trivyignore
+++ b/flavors/python-3.6-minimal-EXASOL-6.2.0/flavor_base/security_scan/.trivyignore
@@ -9,3 +9,5 @@ CVE-2022-1015
 CVE-2022-23648
 #issue in cgroups, but no threat for ScriptLanguageContainer
 CVE-2022-0492
+# CVE-2022-27191 is an issue in Go. Which will be installed only together with Trivy.
+CVE-2022-27191

--- a/flavors/python-3.7-minimal-EXASOL-6.2.0/flavor_base/security_scan/.trivyignore
+++ b/flavors/python-3.7-minimal-EXASOL-6.2.0/flavor_base/security_scan/.trivyignore
@@ -9,3 +9,5 @@ CVE-2022-1015
 CVE-2022-23648
 #issue in cgroups, but no threat for ScriptLanguageContainer
 CVE-2022-0492
+# CVE-2022-27191 is an issue in Go. Which will be installed only together with Trivy.
+CVE-2022-27191

--- a/flavors/python-3.8-minimal-EXASOL-6.2.0/flavor_base/security_scan/.trivyignore
+++ b/flavors/python-3.8-minimal-EXASOL-6.2.0/flavor_base/security_scan/.trivyignore
@@ -11,3 +11,5 @@ CVE-2022-25636
 CVE-2022-23648
 #issue in cgroups, but no threat for ScriptLanguageContainer
 CVE-2022-0492
+# CVE-2022-27191 is an issue in Go. Which will be installed only together with Trivy.
+CVE-2022-27191


### PR DESCRIPTION
CVE-2022-27191 is an issue in Go. Which will be installed only together with Trivy.