### PR TITLE
#623: Removed CVE-2021-43816 from ignore list

### DIFF
--- a/flavors/python-3.6-data-science-cuda-EXASOL-6.2.0/flavor_base/security_scan/.trivyignore
+++ b/flavors/python-3.6-data-science-cuda-EXASOL-6.2.0/flavor_base/security_scan/.trivyignore
@@ -1,5 +1,3 @@
-#bug in trivy, no idea when a new debian package will be released (https://github.com/aquasecurity/trivy/issues/1680)
-CVE-2021-43816
 #the following CVE's affect kernel, no issue for container
 CVE-2022-0847
 CVE-2022-0778

--- a/flavors/python-3.6-minimal-EXASOL-6.2.0/flavor_base/security_scan/.trivyignore
+++ b/flavors/python-3.6-minimal-EXASOL-6.2.0/flavor_base/security_scan/.trivyignore
@@ -1,5 +1,3 @@
-#bug in trivy, no idea when a new debian package will be released (https://github.com/aquasecurity/trivy/issues/1680)
-CVE-2021-43816
 #the following CVE's affect kernel, no issue for container
 CVE-2022-0847
 CVE-2022-0001

--- a/flavors/python-3.7-minimal-EXASOL-6.2.0/flavor_base/security_scan/.trivyignore
+++ b/flavors/python-3.7-minimal-EXASOL-6.2.0/flavor_base/security_scan/.trivyignore
@@ -1,5 +1,3 @@
-#bug in trivy, no idea when a new debian package will be released (https://github.com/aquasecurity/trivy/issues/1680)
-CVE-2021-43816
 #the following CVE's affect kernel, no issue for container
 CVE-2022-0847
 CVE-2022-0001

--- a/flavors/python-3.8-minimal-EXASOL-6.2.0/flavor_base/security_scan/.trivyignore
+++ b/flavors/python-3.8-minimal-EXASOL-6.2.0/flavor_base/security_scan/.trivyignore
@@ -1,5 +1,3 @@
-#bug in trivy, no idea when a new debian package will be released (https://github.com/aquasecurity/trivy/issues/1680)
-CVE-2021-43816
 #the following CVE's affect kernel, no issue for container
 CVE-2022-0847
 CVE-2022-0001


### PR DESCRIPTION
Related to https://github.com/exasol/script-languages-release/issues/623