### PR TITLE
#648: Moved swig-2.0.4.tar.gz to AWS

### DIFF
--- a/flavors/python-3.6-data-science-cuda-EXASOL-6.2.0/flavor_base/build_deps/Dockerfile
+++ b/flavors/python-3.6-data-science-cuda-EXASOL-6.2.0/flavor_base/build_deps/Dockerfile
@@ -23,7 +23,7 @@ RUN apt-get -y update && \
     apt-get -y clean && \
     apt-get -y autoremove
 	  
-RUN curl -L -o swig-2.0.4.tar.gz https://storage.googleapis.com/exasol-script-languages-dependencies/swig-2.0.4.tar.gz && \
+RUN curl -L -o swig-2.0.4.tar.gz https://exasol-script-languages-dependencies.s3.eu-central-1.amazonaws.com/swig-2.0.4.tar.gz && \
     tar zxf swig-2.0.4.tar.gz && \
     (cd swig-2.0.4 && ./configure --prefix=/usr && make && make install) && \
     rm -rf swig-2.0.4 swig-2.0.4.tar.gz

--- a/flavors/python-3.6-minimal-EXASOL-6.2.0/flavor_base/build_deps/Dockerfile
+++ b/flavors/python-3.6-minimal-EXASOL-6.2.0/flavor_base/build_deps/Dockerfile
@@ -23,7 +23,7 @@ RUN apt-get -y update && \
     apt-get -y clean && \
     apt-get -y autoremove
 	  
-RUN curl -L -o swig-2.0.4.tar.gz https://storage.googleapis.com/exasol-script-languages-dependencies/swig-2.0.4.tar.gz && \
+RUN curl -L -o swig-2.0.4.tar.gz https://exasol-script-languages-dependencies.s3.eu-central-1.amazonaws.com/swig-2.0.4.tar.gz && \
     tar zxf swig-2.0.4.tar.gz && \
     (cd swig-2.0.4 && ./configure --prefix=/usr && make && make install) && \
     rm -rf swig-2.0.4 swig-2.0.4.tar.gz

--- a/flavors/python-3.7-minimal-EXASOL-6.2.0/flavor_base/build_deps/Dockerfile
+++ b/flavors/python-3.7-minimal-EXASOL-6.2.0/flavor_base/build_deps/Dockerfile
@@ -23,7 +23,7 @@ RUN apt-get -y update && \
     apt-get -y clean && \
     apt-get -y autoremove
 	  
-RUN curl -L -o swig-2.0.4.tar.gz https://storage.googleapis.com/exasol-script-languages-dependencies/swig-2.0.4.tar.gz && \
+RUN curl -L -o swig-2.0.4.tar.gz https://exasol-script-languages-dependencies.s3.eu-central-1.amazonaws.com/swig-2.0.4.tar.gz && \
     tar zxf swig-2.0.4.tar.gz && \
     (cd swig-2.0.4 && ./configure --prefix=/usr && make && make install) && \
     rm -rf swig-2.0.4 swig-2.0.4.tar.gz

--- a/flavors/python-3.8-minimal-EXASOL-6.2.0/flavor_base/build_deps/Dockerfile
+++ b/flavors/python-3.8-minimal-EXASOL-6.2.0/flavor_base/build_deps/Dockerfile
@@ -23,7 +23,7 @@ RUN apt-get -y update && \
     apt-get -y clean && \
     apt-get -y autoremove
 	  
-RUN curl -L -o swig-2.0.4.tar.gz https://storage.googleapis.com/exasol-script-languages-dependencies/swig-2.0.4.tar.gz && \
+RUN curl -L -o swig-2.0.4.tar.gz https://exasol-script-languages-dependencies.s3.eu-central-1.amazonaws.com/swig-2.0.4.tar.gz && \
     tar zxf swig-2.0.4.tar.gz && \
     (cd swig-2.0.4 && ./configure --prefix=/usr && make && make install) && \
     rm -rf swig-2.0.4 swig-2.0.4.tar.gz


### PR DESCRIPTION
related to https://github.com/exasol/script-languages-release/issues/648

1. Created new S3 Bucket s3://exasol-script-languages-dependencies and deployed swig-2.0.4.tar.gz there
2. Use this new Bucket instead of GCloud