### PR TITLE
#727: Ignore  CVE-2022-23960

### DIFF
--- a/flavors/python-3.6-minimal-EXASOL-6.2.0/flavor_base/security_scan/.trivyignore
+++ b/flavors/python-3.6-minimal-EXASOL-6.2.0/flavor_base/security_scan/.trivyignore
@@ -12,3 +12,5 @@ CVE-2022-23648
 CVE-2022-0492
 # CVE-2022-27191 is an issue in Go. Which will be installed only together with Trivy.
 CVE-2022-27191
+# CVE-2022-23960 affects only ARM architectures
+CVE-2022-23960

--- a/flavors/python-3.7-minimal-EXASOL-6.2.0/flavor_base/security_scan/.trivyignore
+++ b/flavors/python-3.7-minimal-EXASOL-6.2.0/flavor_base/security_scan/.trivyignore
@@ -12,3 +12,5 @@ CVE-2022-23648
 CVE-2022-0492
 # CVE-2022-27191 is an issue in Go. Which will be installed only together with Trivy.
 CVE-2022-27191
+# CVE-2022-23960 affects only ARM architectures
+CVE-2022-23960

--- a/flavors/python-3.8-minimal-EXASOL-6.2.0/flavor_base/security_scan/.trivyignore
+++ b/flavors/python-3.8-minimal-EXASOL-6.2.0/flavor_base/security_scan/.trivyignore
@@ -14,3 +14,5 @@ CVE-2022-23648
 CVE-2022-0492
 # CVE-2022-27191 is an issue in Go. Which will be installed only together with Trivy.
 CVE-2022-27191
+# CVE-2022-23960 affects only ARM architectures
+CVE-2022-23960

--- a/flavors/template-Exasol-all-python-3.8-conda/flavor_base/security_scan/.trivyignore
+++ b/flavors/template-Exasol-all-python-3.8-conda/flavor_base/security_scan/.trivyignore
@@ -13,3 +13,5 @@ CVE-2022-23648
 CVE-2022-0492
 # CVE-2022-27191 is an issue in Go. Which will be installed only together with Trivy.
 CVE-2022-27191
+# CVE-2022-23960 affects only ARM architectures
+CVE-2022-23960

--- a/flavors/template-Exasol-all-python-3.8-cuda-conda/flavor_base/security_scan/.trivyignore
+++ b/flavors/template-Exasol-all-python-3.8-cuda-conda/flavor_base/security_scan/.trivyignore
@@ -13,3 +13,5 @@ CVE-2022-23648
 CVE-2022-0492
 # CVE-2022-27191 is an issue in Go. Which will be installed only together with Trivy.
 CVE-2022-27191
+# CVE-2022-23960 affects only ARM architectures
+CVE-2022-23960


### PR DESCRIPTION
related to https://github.com/exasol/script-languages-release/issues/727