### PR TITLE
#740 update ca certificates

### DIFF
--- a/.github/workflows/check_bazel_tests.yml
+++ b/.github/workflows/check_bazel_tests.yml
@@ -19,7 +19,7 @@ jobs:
 
     - name: Install bazel
       run: |
-        export ENV BAZEL_PACKAGE_VERSION="1.1.0"
+        export ENV BAZEL_PACKAGE_VERSION="5.2.0"
         export ENV BAZEL_PACKAGE_FILE="bazel_$BAZEL_PACKAGE_VERSION-linux-x86_64.deb"
         export BAZEL_PACKAGE_URL="https://github.com/bazelbuild/bazel/releases/download/$BAZEL_PACKAGE_VERSION/$BAZEL_PACKAGE_FILE"
         sudo apt-get -y update && \

--- a/.github/workflows/test_package_management_scripts.yaml
+++ b/.github/workflows/test_package_management_scripts.yaml
@@ -14,7 +14,7 @@ jobs:
     - uses: actions/checkout@v3
     - uses: actions/setup-python@v2
       with:
-        python-version: 3.6
+        python-version: 3.8
     - uses: actions/setup-python@v2
       with:
         python-version: 2.7

--- a/ext/scripts/install_scripts/install_nvidia_driver_libs.sh
+++ b/ext/scripts/install_scripts/install_nvidia_driver_libs.sh
@@ -29,7 +29,7 @@ popd
 
 pushd "$LIB_DIR"
 for lib_file in *"$DRIVER_VERSION"; do
-    lib_file_base="${lib_file%.$DRIVER_VERSION}"
+    lib_file_base="${lib_file%."$DRIVER_VERSION"}"
     ln -sf "$lib_file" "$lib_file_base.1"
     ln -sf "$lib_file_base.1" "$lib_file_base"
 done

--- a/flavors/python-3.6-minimal-EXASOL-6.2.0/flavor_base/base_test_deps/packages/apt_get_packages
+++ b/flavors/python-3.6-minimal-EXASOL-6.2.0/flavor_base/base_test_deps/packages/apt_get_packages
@@ -3,7 +3,7 @@ python-zmq|16.0.2-2build2
 gdb|8.1.1-0ubuntu1
 valgrind|1:3.13.0-2ubuntu2.3
 gdbserver|8.1.1-0ubuntu1
-binutils|2.30-21ubuntu1~18.04.7
+binutils|2.30-21ubuntu1~18.04.8
 patchelf|0.9-1
 chrpath|0.16-2
 strace|4.21-1ubuntu1

--- a/flavors/python-3.6-minimal-EXASOL-6.2.0/flavor_base/build_deps/Dockerfile
+++ b/flavors/python-3.6-minimal-EXASOL-6.2.0/flavor_base/build_deps/Dockerfile
@@ -10,7 +10,7 @@ COPY scripts /scripts
 RUN mkdir -p /build_info/packages
 COPY build_deps/packages /build_info/packages/build_deps
 
-ENV BAZEL_PACKAGE_VERSION="1.1.0"
+ENV BAZEL_PACKAGE_VERSION="5.2.0"
 ENV BAZEL_PACKAGE_FILE="bazel_$BAZEL_PACKAGE_VERSION-linux-x86_64.deb"
 ENV BAZEL_PACKAGE_URL="https://github.com/bazelbuild/bazel/releases/download/$BAZEL_PACKAGE_VERSION/$BAZEL_PACKAGE_FILE"
 

--- a/flavors/python-3.6-minimal-EXASOL-6.2.0/flavor_base/language_deps/packages/apt_get_packages
+++ b/flavors/python-3.6-minimal-EXASOL-6.2.0/flavor_base/language_deps/packages/apt_get_packages
@@ -1,4 +1,4 @@
-ca-certificates|20211016~18.04.1
+ca-certificates|20211016ubuntu0.18.04.1
 python3.6-dev|3.6.9-1~18.04ubuntu1.8
 python3-distutils|3.6.9-1~18.04
 curl|7.58.0-2ubuntu3.21

--- a/flavors/python-3.7-minimal-EXASOL-6.2.0/flavor_base/base_test_deps/packages/apt_get_packages
+++ b/flavors/python-3.7-minimal-EXASOL-6.2.0/flavor_base/base_test_deps/packages/apt_get_packages
@@ -3,7 +3,7 @@ python-zmq|16.0.2-2build2
 gdb|8.1.1-0ubuntu1
 valgrind|1:3.13.0-2ubuntu2.3
 gdbserver|8.1.1-0ubuntu1
-binutils|2.30-21ubuntu1~18.04.7
+binutils|2.30-21ubuntu1~18.04.8
 patchelf|0.9-1
 chrpath|0.16-2
 strace|4.21-1ubuntu1

--- a/flavors/python-3.7-minimal-EXASOL-6.2.0/flavor_base/build_deps/Dockerfile
+++ b/flavors/python-3.7-minimal-EXASOL-6.2.0/flavor_base/build_deps/Dockerfile
@@ -10,7 +10,7 @@ COPY scripts /scripts
 RUN mkdir -p /build_info/packages
 COPY build_deps/packages /build_info/packages/build_deps
 
-ENV BAZEL_PACKAGE_VERSION="1.1.0"
+ENV BAZEL_PACKAGE_VERSION="5.2.0"
 ENV BAZEL_PACKAGE_FILE="bazel_$BAZEL_PACKAGE_VERSION-linux-x86_64.deb"
 ENV BAZEL_PACKAGE_URL="https://github.com/bazelbuild/bazel/releases/download/$BAZEL_PACKAGE_VERSION/$BAZEL_PACKAGE_FILE"
 

--- a/flavors/python-3.7-minimal-EXASOL-6.2.0/flavor_base/language_deps/packages/apt_get_packages
+++ b/flavors/python-3.7-minimal-EXASOL-6.2.0/flavor_base/language_deps/packages/apt_get_packages
@@ -1,2 +1,2 @@
 curl|7.58.0-2ubuntu3.21
-ca-certificates|20211016~18.04.1
+ca-certificates|20211016ubuntu0.18.04.1

--- a/flavors/python-3.7-minimal-EXASOL-6.2.0/flavor_base/language_deps/packages/apt_get_packages_python
+++ b/flavors/python-3.7-minimal-EXASOL-6.2.0/flavor_base/language_deps/packages/apt_get_packages_python
@@ -1,3 +1,3 @@
-python3.7-dev|3.7.15-1+bionic1
-python3.7|3.7.15-1+bionic1
+python3.7-dev|3.7.16-1+bionic1
+python3.7|3.7.16-1+bionic1
 python3-distutils|3.6.9-1~18.04 # Note: required by install_python3.7_pip.sh

--- a/flavors/python-3.8-minimal-EXASOL-6.2.0/flavor_base/base_test_deps/packages/apt_get_packages
+++ b/flavors/python-3.8-minimal-EXASOL-6.2.0/flavor_base/base_test_deps/packages/apt_get_packages
@@ -2,6 +2,6 @@ python-protobuf|3.6.1.3-2ubuntu5
 gdb|9.2-0ubuntu1~20.04.1
 valgrind|1:3.15.0-1ubuntu9.1
 gdbserver|9.2-0ubuntu1~20.04.1
-binutils|2.34-6ubuntu1.3
+binutils|2.34-6ubuntu1.4
 patchelf|0.10-2build1
 strace|5.5-3ubuntu1

--- a/flavors/python-3.8-minimal-EXASOL-6.2.0/flavor_base/build_deps/Dockerfile
+++ b/flavors/python-3.8-minimal-EXASOL-6.2.0/flavor_base/build_deps/Dockerfile
@@ -10,7 +10,7 @@ COPY scripts /scripts
 RUN mkdir -p /build_info/packages
 COPY build_deps/packages /build_info/packages/build_deps
 
-ENV BAZEL_PACKAGE_VERSION="1.1.0"
+ENV BAZEL_PACKAGE_VERSION="5.2.0"
 ENV BAZEL_PACKAGE_FILE="bazel_$BAZEL_PACKAGE_VERSION-linux-x86_64.deb"
 ENV BAZEL_PACKAGE_URL="https://github.com/bazelbuild/bazel/releases/download/$BAZEL_PACKAGE_VERSION/$BAZEL_PACKAGE_FILE"
 

--- a/flavors/python-3.8-minimal-EXASOL-6.2.0/flavor_base/language_deps/packages/apt_get_packages
+++ b/flavors/python-3.8-minimal-EXASOL-6.2.0/flavor_base/language_deps/packages/apt_get_packages
@@ -1,4 +1,4 @@
-ca-certificates|20211016~20.04.1
+ca-certificates|20211016ubuntu0.20.04.1
 python3.8-dev|3.8.10-0ubuntu1~20.04.5
 python3-distutils|3.8.10-0ubuntu1~20.04
 curl|7.68.0-1ubuntu2.14

--- a/flavors/template-Exasol-all-python-3.8-conda/flavor_base/conda_deps/packages/apt_get_packages
+++ b/flavors/template-Exasol-all-python-3.8-conda/flavor_base/conda_deps/packages/apt_get_packages
@@ -1,4 +1,4 @@
 coreutils|8.30-3ubuntu2
 locales|2.31-0ubuntu9.9
 curl|7.68.0-1ubuntu2.14
-ca-certificates|20211016~20.04.1 
+ca-certificates|20211016ubuntu0.20.04.1

--- a/flavors/template-Exasol-all-python-3.8-cuda-conda/flavor_base/nvidia_driver_deps/packages/apt_get_packages
+++ b/flavors/template-Exasol-all-python-3.8-cuda-conda/flavor_base/nvidia_driver_deps/packages/apt_get_packages
@@ -1,4 +1,4 @@
 coreutils|8.30-3ubuntu2
 locales|2.31-0ubuntu9.9
 curl|7.68.0-1ubuntu2.14
-ca-certificates|20211016~20.04.1 
+ca-certificates|20211016ubuntu0.20.04.1

--- a/tests/Dockerfile
+++ b/tests/Dockerfile
@@ -22,9 +22,9 @@ RUN apt-get -y update && \
 RUN curl -fsSL https://get.docker.com -o get-docker.sh && sh get-docker.sh
 
 RUN mkdir -p downloads/ODBC downloads/JDBC downloads/EXAplus
-RUN curl -s https://www.exasol.com/support/secure/attachment/65437/EXASOL_ODBC-6.0.11.tar.gz | tar -C downloads/ODBC --strip-components 1 -zxf -
-RUN curl -s https://www.exasol.com/support/secure/attachment/60963/EXASOL_JDBC-6.0.8.tar.gz | tar -C downloads/JDBC --strip-components 1 -zxf -
-RUN curl -s https://www.exasol.com/support/secure/attachment/63966/EXAplus-6.0.10.tar.gz | tar -C downloads/EXAplus --strip-components 1 -zxf -
+RUN curl -s https://x-up.s3.amazonaws.com/7.x/7.1.16/EXASOL_ODBC-7.1.16.tar.gz | tar -C downloads/ODBC --strip-components 1 -zxf -
+RUN curl -s https://x-up.s3.amazonaws.com/7.x/7.1.14/EXASOL_JDBC-7.1.14.tar.gz | tar -C downloads/JDBC --strip-components 1 -zxf -
+RUN curl -s https://x-up.s3.amazonaws.com/7.x/7.1.16/EXAplus-7.1.16.tar.gz | tar -C downloads/EXAplus --strip-components 1 -zxf -
 ENV EXAPLUS=/downloads/EXAplus/exaplus
 
 COPY requirements.txt requirements.txt

--- a/tests/Dockerfile
+++ b/tests/Dockerfile
@@ -24,7 +24,7 @@ RUN curl -fsSL https://get.docker.com -o get-docker.sh && sh get-docker.sh
 RUN mkdir -p downloads/ODBC downloads/JDBC downloads/EXAplus
 RUN curl -s https://exasol-script-languages-dependencies.s3.eu-central-1.amazonaws.com/EXASOL_ODBC-7.0.11.tar.gz | tar -C downloads/ODBC --strip-components 1 -zxf -
 RUN curl -s https://x-up.s3.amazonaws.com/7.x/7.1.14/EXASOL_JDBC-7.1.14.tar.gz | tar -C downloads/JDBC --strip-components 1 -zxf -
-RUN curl -s https://x-up.s3.amazonaws.com/7.x/7.1.16/EXAplus-7.1.16.tar.gz | tar -C downloads/EXAplus --strip-components 1 -zxf -
+RUN curl -s https://exasol-script-languages-dependencies.s3.eu-central-1.amazonaws.com/EXAplus-7.0.11.tar.gz | tar -C downloads/EXAplus --strip-components 1 -zxf -
 ENV EXAPLUS=/downloads/EXAplus/exaplus
 
 COPY requirements.txt requirements.txt

--- a/tests/Dockerfile
+++ b/tests/Dockerfile
@@ -22,7 +22,7 @@ RUN apt-get -y update && \
 RUN curl -fsSL https://get.docker.com -o get-docker.sh && sh get-docker.sh
 
 RUN mkdir -p downloads/ODBC downloads/JDBC downloads/EXAplus
-RUN curl -s https://x-up.s3.amazonaws.com/7.x/7.1.16/EXASOL_ODBC-7.1.16.tar.gz | tar -C downloads/ODBC --strip-components 1 -zxf -
+RUN curl -s https://exasol-script-languages-dependencies.s3.eu-central-1.amazonaws.com/EXASOL_ODBC-7.0.11.tar.gz | tar -C downloads/ODBC --strip-components 1 -zxf -
 RUN curl -s https://x-up.s3.amazonaws.com/7.x/7.1.14/EXASOL_JDBC-7.1.14.tar.gz | tar -C downloads/JDBC --strip-components 1 -zxf -
 RUN curl -s https://x-up.s3.amazonaws.com/7.x/7.1.16/EXAplus-7.1.16.tar.gz | tar -C downloads/EXAplus --strip-components 1 -zxf -
 ENV EXAPLUS=/downloads/EXAplus/exaplus


### PR DESCRIPTION
related to https://github.com/exasol/script-languages-release/issues/740

## Changes
1. Update Ubuntu 18.04/20.04 binutils/ca-certificates/Python3.7 packages
2. Fixed a shellcheck finding (found by a newer version of shellcheck)
3. Upgraded Bazel in all flavors and GH Workflow
4. Updated dependencies in TestContainer