### PR TITLE
Fixed Java module test

### DIFF
--- a/test_container/tests/test/java/java_modules.py
+++ b/test_container/tests/test/java/java_modules.py
@@ -53,9 +53,10 @@ class JavaModules(udf.TestCase):
     def upload_to_bucketfs(self, path: Path) -> str:
         docker_db_container = self.env.get_docker_db_container()
         docker_db_ip = self.env.get_ip_address_of_container(docker_db_container)
-        upload_url = f"http://{docker_db_ip}:6583/myudfs/{path.name}"
+        upload_url = f"http://{docker_db_ip}:2580/myudfs/{path.name}"
         username = "w"
         password = "write"
+        print(f"Trying to upload to {upload_url}")
         r_upload = requests.put(upload_url, data=path.read_bytes(), auth=HTTPBasicAuth(username, password))
         r_upload.raise_for_status()
         return f"/buckets/bfsdefault/myudfs/{path.name}"


### PR DESCRIPTION
Since we are now using ITDE 3.0.0, we need to switch the bucketfs port which was changed to `2580` in https://github.com/exasol/integration-test-docker-environment/releases/tag/2.0.0. See https://github.com/exasol/integration-test-docker-environment/issues/308