### PR TITLE
Added sleep in dataframe_memory_leak test after gc collection

### DIFF
--- a/test_container/tests/test/pandas/all/dataframe_memory_leak.py
+++ b/test_container/tests/test/pandas/all/dataframe_memory_leak.py
@@ -93,6 +93,7 @@ class PandasDataFrameMemoryLeakTest(udf.TestCase):
 
             import tracemalloc
             import gc
+            import time
             snapshot_begin = None
             memory_check_executed = False
             tracemalloc.start()
@@ -111,6 +112,7 @@ class PandasDataFrameMemoryLeakTest(udf.TestCase):
                     assert memory_check_executed == False #Sanity check for row number
                     print("Checking memory usage", flush=True)
                     gc.collect()
+                    time.sleep(1)
                     snapshot_end = tracemalloc.take_snapshot()
                     top_stats_begin_end = snapshot_end.compare_to(snapshot_begin, 'lineno')
                     first_item = top_stats_begin_end[0] #First item is always the largest one
@@ -203,6 +205,7 @@ class PandasDataFrameMemoryLeakTest(udf.TestCase):
 
             import tracemalloc
             import gc
+            import time
             snapshot_begin = None
             memory_check_executed = False
             tracemalloc.start()
@@ -220,6 +223,7 @@ class PandasDataFrameMemoryLeakTest(udf.TestCase):
                     assert memory_check_executed == False #Sanity check for row number
                     print("Checking memory usage", flush=True)
                     gc.collect()
+                    time.sleep(1)
                     snapshot_end = tracemalloc.take_snapshot()
                     top_stats_begin_end = snapshot_end.compare_to(snapshot_begin, 'lineno')
                     first_item = top_stats_begin_end[0] #First item is always the largest one
@@ -254,6 +258,7 @@ class PandasDataFrameMemoryLeakTest(udf.TestCase):
 
                     import tracemalloc
                     import gc
+                    import time
                     tracemalloc.start()
 
                     def process_df(ctx):
@@ -272,6 +277,7 @@ class PandasDataFrameMemoryLeakTest(udf.TestCase):
 
                             if batch_idx == ({batch_count} - 1):
                                 gc.collect()
+                                time.sleep(1)
                                 snapshot_end = tracemalloc.take_snapshot()
                                 top_stats_begin_end = snapshot_end.compare_to(snapshot_begin, 'lineno')
                                 first_item = top_stats_begin_end[0] #First item is always the largest one

--- a/test_container/tests/test/pandas/all/dataframe_memory_leak.py
+++ b/test_container/tests/test/pandas/all/dataframe_memory_leak.py
@@ -112,7 +112,7 @@ class PandasDataFrameMemoryLeakTest(udf.TestCase):
                     assert memory_check_executed == False #Sanity check for row number
                     print("Checking memory usage", flush=True)
                     gc.collect()
-                    time.sleep(1)
+                    time.sleep(1) #Need to sleep here. Otherwise GC might not have finished before taking snapshot.
                     snapshot_end = tracemalloc.take_snapshot()
                     top_stats_begin_end = snapshot_end.compare_to(snapshot_begin, 'lineno')
                     first_item = top_stats_begin_end[0] #First item is always the largest one
@@ -151,6 +151,7 @@ class PandasDataFrameMemoryLeakTest(udf.TestCase):
 
             import tracemalloc
             import gc
+            import time
             snapshot_begin = None
             memory_check_executed = False
             tracemalloc.start()
@@ -171,6 +172,7 @@ class PandasDataFrameMemoryLeakTest(udf.TestCase):
                     assert memory_check_executed == False #Sanity check for row number
                     print("Checking memory usage", flush=True)
                     gc.collect()
+                    time.sleep(1) #Need to sleep here. Otherwise GC might not have finished before taking snapshot.
                     snapshot_end = tracemalloc.take_snapshot()
                     top_stats_begin_end = snapshot_end.compare_to(snapshot_begin, 'lineno')
                     first_item = top_stats_begin_end[0] #First item is always the largest one
@@ -223,7 +225,7 @@ class PandasDataFrameMemoryLeakTest(udf.TestCase):
                     assert memory_check_executed == False #Sanity check for row number
                     print("Checking memory usage", flush=True)
                     gc.collect()
-                    time.sleep(1)
+                    time.sleep(1) #Need to sleep here. Otherwise GC might not have finished before taking snapshot.
                     snapshot_end = tracemalloc.take_snapshot()
                     top_stats_begin_end = snapshot_end.compare_to(snapshot_begin, 'lineno')
                     first_item = top_stats_begin_end[0] #First item is always the largest one
@@ -277,7 +279,7 @@ class PandasDataFrameMemoryLeakTest(udf.TestCase):
 
                             if batch_idx == ({batch_count} - 1):
                                 gc.collect()
-                                time.sleep(1)
+                                time.sleep(1) #Need to sleep here. Otherwise GC might not have finished before taking snapshot.
                                 snapshot_end = tracemalloc.take_snapshot()
                                 top_stats_begin_end = snapshot_end.compare_to(snapshot_begin, 'lineno')
                                 first_item = top_stats_begin_end[0] #First item is always the largest one


### PR DESCRIPTION
related to https://github.com/exasol/script-languages-release/issues/1060

We suspect that GC is not finished when the test reads the memory snapshot => Sleep 1s after triggerer GC might fix this problem.
I ran the AWS Build with https://github.com/exasol/script-languages-release/pull/1061 3x and it worked. So the workaround looks promising.