### PR TITLE
#1100: Ignore python module setuptools.command.bdist_wheel in import test

### DIFF
--- a/test_container/tests/test/standard-flavor/all/python/import_modules.py
+++ b/test_container/tests/test/standard-flavor/all/python/import_modules.py
@@ -140,7 +140,8 @@ class ImportAllModulesTest(udf.TestCase):
                 "msrest.pipeline.aiohttp",
                 "docker.transport.npipesocket",
                 "docker.transport.npipeconn",
-                "tenacity.tornadoweb"
+                "tenacity.tornadoweb",
+                "setuptools.command.bdist_wheel"
             }
             excluded_submodules = (
                 "sphinxext",


### PR DESCRIPTION
related to https://github.com/exasol/script-languages-release/issues/1100