### PR TITLE
#1145/#1147: Ignore CVE-2025-47273 and remove unnecessary copy

### DIFF
--- a/flavors/test-Exasol-8-cuda-ml/flavor_base/flavor_base_deps/packages/conda_packages
+++ b/flavors/test-Exasol-8-cuda-ml/flavor_base/flavor_base_deps/packages/conda_packages
@@ -4,4 +4,4 @@ cuda-compat|12.6.2
 cuda-nvcc|12.6.77
 cuda-nvrtc|12.6.77
 numba|0.60.0
-pytorch|2.6.0
+pytorch|2.7.0

--- a/flavors/test-Exasol-8-cuda-ml/flavor_base/release/Dockerfile
+++ b/flavors/test-Exasol-8-cuda-ml/flavor_base/release/Dockerfile
@@ -6,25 +6,7 @@ ENV MAMBA_EXE="/bin/micromamba"
 
 RUN mkdir -p /conf /buckets /nvidia/driver /nvidia/utils
 
-COPY --from={{language_deps}} /usr /usr
-RUN true # workaround for https://github.com/moby/moby/issues/37965
-
-COPY --from={{language_deps}} /lib /lib
-RUN true # workaround for https://github.com/moby/moby/issues/37965
-
-COPY --from={{language_deps}} /bin /bin
-RUN true # workaround for https://github.com/moby/moby/issues/37965
-
-COPY --from={{language_deps}} /opt /opt
-RUN true # workaround for https://github.com/moby/moby/issues/37965
-
-COPY --from={{language_deps}} /etc /etc
-RUN true # workaround for https://github.com/moby/moby/issues/37965
-
 COPY --from={{language_deps}} /build_info /build_info
-RUN true # workaround for https://github.com/moby/moby/issues/37965
-
-COPY --from={{language_deps}} /var /var
 RUN true # workaround for https://github.com/moby/moby/issues/37965
 
 COPY --from={{language_deps}} /scripts /scripts

--- a/flavors/test-Exasol-8-cuda-ml/flavor_base/security_scan/.trivyignore
+++ b/flavors/test-Exasol-8-cuda-ml/flavor_base/security_scan/.trivyignore
@@ -1,1 +1,1 @@
-
+CVE-2025-47273 #See https://github.com/exasol/script-languages-release/issues/1145


### PR DESCRIPTION
related to https://github.com/exasol/script-languages-release/issues/1145
related to https://github.com/exasol/script-languages-release/issues/1147

- also update `pytorch` to 2.7.0
