### PR TITLE
#1132: Use headless openjdk for all build buildsteps

### DIFF
--- a/flavors/template-Exasol-all-python-3.10/flavor_base/build_deps/packages/apt_get_packages
+++ b/flavors/template-Exasol-all-python-3.10/flavor_base/build_deps/packages/apt_get_packages
@@ -2,7 +2,7 @@ coreutils|8.32-4.1ubuntu1.2
 locales|2.35-0ubuntu3.9
 tar|1.34+dfsg-1ubuntu0.1.22.04.2
 curl|7.81.0-1ubuntu1.20
-openjdk-11-jdk|11.0.27+6~us1-0ubuntu1~22.04
+openjdk-11-jdk-headless|11.0.27+6~us1-0ubuntu1~22.04
 build-essential|12.9ubuntu3
 libpcre3-dev|2:8.39-13ubuntu0.22.04.1
 protobuf-compiler|3.12.4-1ubuntu7.22.04.2


### PR DESCRIPTION
related to https://github.com/exasol/script-languages-release/issues/1132