### PR TITLE
#1146: Removed the CVE-2025-47273 from .trivyignore

### DIFF
--- a/flavors/test-Exasol-8-cuda-ml/flavor_base/security_scan/.trivyignore
+++ b/flavors/test-Exasol-8-cuda-ml/flavor_base/security_scan/.trivyignore
@@ -1,2 +1,1 @@
-CVE-2025-47273 #See https://github.com/exasol/script-languages-release/issues/1145
 CVE-2025-47907 #This affects nsight-compute version 2025.2.1. Ignoring for now


### PR DESCRIPTION
relates to #1146

Sometime back we had to [ignore](https://github.com/exasol/script-languages-release/issues/1146) the CVE-2025-47273. But now, those packages are updated, hence ignoring