### PR TITLE
#1253/#1254: Suppressed CVE-2025-47906 in Cuda flavors and package updates

### DIFF
--- a/flavors/template-Exasol-8-python-3.10-cuda-conda/flavor_base/conda_deps/packages/apt_get_packages
+++ b/flavors/template-Exasol-8-python-3.10-cuda-conda/flavor_base/conda_deps/packages/apt_get_packages
@@ -1,5 +1,5 @@
 coreutils|8.32-4.1ubuntu1.2
-locales|2.35-0ubuntu3.10
+locales|2.35-0ubuntu3.11
 curl|7.81.0-1ubuntu1.20
 ca-certificates|20240203~22.04.1
 bzip2|1.0.8-5build1

--- a/flavors/template-Exasol-8-python-3.10-cuda-conda/flavor_base/security_scan/.trivyignore
+++ b/flavors/template-Exasol-8-python-3.10-cuda-conda/flavor_base/security_scan/.trivyignore
@@ -1,1 +1,2 @@
 CVE-2025-47907 #This affects nsight-compute version 2025.2.1. Ignoring for now
+CVE-2025-47906 #This affects nsight-compute version 2025.2.1. Ignoring for now

--- a/flavors/template-Exasol-all-python-3.10-conda/flavor_base/conda_deps/packages/apt_get_packages
+++ b/flavors/template-Exasol-all-python-3.10-conda/flavor_base/conda_deps/packages/apt_get_packages
@@ -1,5 +1,5 @@
 coreutils|8.32-4.1ubuntu1.2
-locales|2.35-0ubuntu3.10
+locales|2.35-0ubuntu3.11
 curl|7.81.0-1ubuntu1.20
 ca-certificates|20240203~22.04.1
 bzip2|1.0.8-5build1

--- a/flavors/template-Exasol-all-python-3.10/flavor_base/build_deps/packages/apt_get_packages
+++ b/flavors/template-Exasol-all-python-3.10/flavor_base/build_deps/packages/apt_get_packages
@@ -1,5 +1,5 @@
 coreutils|8.32-4.1ubuntu1.2
-locales|2.35-0ubuntu3.10
+locales|2.35-0ubuntu3.11
 tar|1.34+dfsg-1ubuntu0.1.22.04.2
 curl|7.81.0-1ubuntu1.20
 openjdk-11-jdk-headless|11.0.28+6-1ubuntu1~22.04.1

--- a/flavors/template-Exasol-all-python-3.10/flavor_base/udfclient_deps/packages/apt_get_packages
+++ b/flavors/template-Exasol-all-python-3.10/flavor_base/udfclient_deps/packages/apt_get_packages
@@ -1,5 +1,5 @@
 coreutils|8.32-4.1ubuntu1.2
-locales|2.35-0ubuntu3.10
+locales|2.35-0ubuntu3.11
 libnss-db|2.2.3pre1-6ubuntu3
 libzmq3-dev|4.3.4-2
 libprotobuf-dev|3.12.4-1ubuntu7.22.04.4

--- a/flavors/test-Exasol-8-cuda-ml/flavor_base/conda_deps/packages/apt_get_packages
+++ b/flavors/test-Exasol-8-cuda-ml/flavor_base/conda_deps/packages/apt_get_packages
@@ -1,5 +1,5 @@
 coreutils|8.32-4.1ubuntu1.2
-locales|2.35-0ubuntu3.10
+locales|2.35-0ubuntu3.11
 curl|7.81.0-1ubuntu1.20
 ca-certificates|20240203~22.04.1
 bzip2|1.0.8-5build1

--- a/flavors/test-Exasol-8-cuda-ml/flavor_base/security_scan/.trivyignore
+++ b/flavors/test-Exasol-8-cuda-ml/flavor_base/security_scan/.trivyignore
@@ -1,1 +1,2 @@
 CVE-2025-47907 #This affects nsight-compute version 2025.2.1. Ignoring for now
+CVE-2025-47906 #This affects nsight-compute version 2025.2.1. Ignoring for now


### PR DESCRIPTION
Related to https://github.com/exasol/script-languages-release/issues/1253
Related to https://github.com/exasol/script-languages-release/issues/1254