### PR TITLE
Updated ca-certificates for Ubuntu 22.04 and 24.04 (fixes #1480)

### DIFF
--- a/flavors/template-Exasol-8-python-3.10-cuda-conda/packages.yml
+++ b/flavors/template-Exasol-8-python-3.10-cuda-conda/packages.yml
@@ -11,7 +11,7 @@ build_steps:
       - name: curl
         version: 7.81.0-1ubuntu*
       - name: ca-certificates
-        version: 20240203~22.04.1
+        version: 20260601~22.04.1
       - name: bzip2
         version: 1.0.8-5build1
       - name: libxml2

--- a/flavors/template-Exasol-8-python-3.12-cuda-conda/packages.yml
+++ b/flavors/template-Exasol-8-python-3.12-cuda-conda/packages.yml
@@ -13,7 +13,7 @@ build_steps:
       - name: curl
         version: 8.5.0-2ubuntu*
       - name: ca-certificates
-        version: '20240203'
+        version: '20260601~24.04.1'
       - name: bzip2
         version: 1.0.8-5.1build0.1
       - name: libxml2

--- a/flavors/template-Exasol-all-python-3.10-conda/packages.yml
+++ b/flavors/template-Exasol-all-python-3.10-conda/packages.yml
@@ -11,7 +11,7 @@ build_steps:
       - name: curl
         version: 7.81.0-1ubuntu*
       - name: ca-certificates
-        version: 20240203~22.04.1
+        version: 20260601~22.04.1
       - name: bzip2
         version: 1.0.8-5build1
       - name: libxml2

--- a/flavors/template-Exasol-all-python-3.10/packages.yml
+++ b/flavors/template-Exasol-all-python-3.10/packages.yml
@@ -29,7 +29,7 @@ build_steps:
     apt:
       packages:
       - name: ca-certificates
-        version: 20240203~22.04.1
+        version: 20260601~22.04.1
       - name: python3.10-dev
         version: 3.10.12-1~22.04.15
       - name: python3-distutils

--- a/flavors/template-Exasol-all-python-3.12-conda/packages.yml
+++ b/flavors/template-Exasol-all-python-3.12-conda/packages.yml
@@ -13,7 +13,7 @@ build_steps:
       - name: curl
         version: 8.5.0-2ubuntu*
       - name: ca-certificates
-        version: '20240203'
+        version: '20260601~24.04.1'
       - name: bzip2
         version: 1.0.8-5.1build0.1
       - name: libxml2

--- a/flavors/template-Exasol-all-python-3.12/packages.yml
+++ b/flavors/template-Exasol-all-python-3.12/packages.yml
@@ -5,7 +5,7 @@ build_steps:
     apt:
       packages:
       - name: ca-certificates
-        version: '20240203'
+        version: '20260601~24.04.1'
       - name: python3.12-dev
         version: 3.12.3-1ubuntu*
       - name: curl

--- a/flavors/test-Exasol-8-cuda-ml/packages.yml
+++ b/flavors/test-Exasol-8-cuda-ml/packages.yml
@@ -13,7 +13,7 @@ build_steps:
       - name: curl
         version: 8.5.0-2ubuntu*
       - name: ca-certificates
-        version: '20240203'
+        version: '20260601~24.04.1'
       - name: bzip2
         version: 1.0.8-5.1build0.1
       - name: libxml2


### PR DESCRIPTION
Related to https://github.com/exasol/script-languages-release/issues/1480